### PR TITLE
Migrate NonBlockingCallback to BalEnv

### DIFF
--- a/grpc-native/src/main/java/org/ballerinalang/net/grpc/DataContext.java
+++ b/grpc-native/src/main/java/org/ballerinalang/net/grpc/DataContext.java
@@ -19,25 +19,25 @@
 package org.ballerinalang.net.grpc;
 
 import org.ballerinalang.jvm.scheduling.Strand;
-import org.ballerinalang.jvm.values.connector.NonBlockingCallback;
+import org.ballerinalang.jvm.api.BalFuture;
 
 /**
- * {@code DataContext} is the wrapper to hold {@code Strand} and {@code NonBlockingCallback}.
+ * {@code DataContext} is the wrapper to hold {@code Strand} and {@code BalFuture}.
  */
 public class DataContext {
     private Strand strand = null;
-    private NonBlockingCallback callback = null;
+    private BalFuture balFuture = null;
 
-    public DataContext(Strand strand, NonBlockingCallback callback) {
+    public DataContext(Strand strand, BalFuture balFuture) {
         this.strand = strand;
-        this.callback = callback;
+        this.balFuture = balFuture;
     }
 
     public Strand getStrand() {
         return strand;
     }
 
-    public NonBlockingCallback getCallback() {
-        return callback;
+    public BalFuture getFuture() {
+        return balFuture;
     }
 }

--- a/grpc-native/src/main/java/org/ballerinalang/net/grpc/stubs/BlockingStub.java
+++ b/grpc-native/src/main/java/org/ballerinalang/net/grpc/stubs/BlockingStub.java
@@ -121,11 +121,10 @@ public class BlockingStub extends AbstractStub {
                 httpConnectorError = MessageUtils.getConnectorError(status.asRuntimeException());
             }
             if (inboundResponse != null) {
-                dataContext.getCallback().setReturnValues(inboundResponse);
+                dataContext.getFuture().complete(inboundResponse);
             } else {
-                dataContext.getCallback().setReturnValues(httpConnectorError);
+                dataContext.getFuture().complete(httpConnectorError);
             }
-            dataContext.getCallback().notifySuccess();
         }
     }
 }


### PR DESCRIPTION
## Purpose
Remove deprecated API

## Goals
Replace deprecated API NonBlockingCallback with BalEnv param for interop

## Related PRs
API deprecated in - ballerina-platform/ballerina-lang#25787
Duplicate change prior to stdlib move - ballerina-platform/ballerina-lang#25854
