### PR TITLE
Replace deprecated usage of addMainTag

### DIFF
--- a/grpc-native/src/main/java/org/ballerinalang/net/grpc/ServerConnectorListener.java
+++ b/grpc-native/src/main/java/org/ballerinalang/net/grpc/ServerConnectorListener.java
@@ -151,10 +151,10 @@ public class ServerConnectorListener implements HttpConnectorListener {
         Map<String, String> httpHeaders = new HashMap<>();
         inboundMessage.getHeaders().forEach(entry -> httpHeaders.put(entry.getKey(), entry.getValue()));
         observerContext.addProperty(PROPERTY_TRACE_PROPERTIES, httpHeaders);
-        observerContext.addMainTag(TAG_KEY_HTTP_METHOD,
+        observerContext.addTag(TAG_KEY_HTTP_METHOD,
                 (String) inboundMessage.getProperty(HttpConstants.HTTP_REQUEST_METHOD.getValue()));
-        observerContext.addMainTag(TAG_KEY_PROTOCOL, (String) inboundMessage.getProperty(HttpConstants.PROTOCOL));
-        observerContext.addMainTag(TAG_KEY_HTTP_URL, inboundMessage.getPath());
+        observerContext.addTag(TAG_KEY_PROTOCOL, (String) inboundMessage.getProperty(HttpConstants.PROTOCOL));
+        observerContext.addTag(TAG_KEY_HTTP_URL, inboundMessage.getPath());
         return observerContext;
     }
 


### PR DESCRIPTION
## Purpose
> With the removal of separation of tags in ballerina-platform/ballerina-lang#26578 `addMainTag` had been deprecated. The usages needs to be removed.

## Goals
> Remove usages of deprecated methods in the ObserverContext

## Approach
> `addMainTag` had been changed to `addTag`

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A