### PR TITLE
Migrate to configurable variables

### DIFF
--- a/grpc-ballerina/client_connection_pool.bal
+++ b/grpc-ballerina/client_connection_pool.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/config;
 import ballerina/java;
 
 # Configurations for managing the gRPC client connection pool.
@@ -24,10 +23,10 @@ import ballerina/java;
 # + waitTimeInMillis - Maximum amount of time the client should wait for an idle connection before it sends an error when the pool is exhausted
 # + maxActiveStreamsPerConnection - Maximum active streams per connection. This only applies to HTTP/2
 public type PoolConfiguration record {|
-    int maxActiveConnections = config:getAsInt("b7a.http.pool.maxActiveConnections", -1);
-    int maxIdleConnections = config:getAsInt("b7a.http.pool.maxIdleConnections", 1000);
-    int waitTimeInMillis = config:getAsInt("b7a.http.pool.waitTimeInMillis", 60000);
-    int maxActiveStreamsPerConnection = config:getAsInt("b7a.http.pool.maxActiveStreamsPerConnection", 50);
+    int maxActiveConnections = -1;
+    int maxIdleConnections = 1000;
+    int waitTimeInMillis = 60000;
+    int maxActiveStreamsPerConnection = 50;
 |};
 
 //This is a hack to get the global map initialized, without involving locking.

--- a/grpc-ballerina/tests/datafiles/service_config.conf
+++ b/grpc-ballerina/tests/datafiles/service_config.conf
@@ -1,8 +1,3 @@
-"backendEP.port"="7070"
-
-[hello]
-basePath="/hello"
-
 [b7a.users]
 
 [b7a.users.alice]


### PR DESCRIPTION
## Purpose
$subject
Some config API parts are not migrated due to module-ballerina-auth dependency. 

## Goals
N/A

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
[BBE](https://ballerina.io/swan-lake/learn/by-example/configurable.html)

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > updated existing tests
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
jdk-11.0 , Ubuntu 20.04
 
## Learning
