### PR TITLE
Enable grpc:Error in server streaming and custom stream creator

### DIFF
--- a/grpc-ballerina/client_endpoint.bal
+++ b/grpc-ballerina/client_endpoint.bal
@@ -70,15 +70,15 @@ public client class Client {
 
     # Calls when executing a server streaming call with a gRPC service.
     # ```ballerina
-    # stream<anydata>|grpc:Error result = grpcClient->executeServerStreaming("HelloWorld/hello", req, headers);
+    # stream<anydata, grpc:Error?>|grpc:Error result = grpcClient->executeServerStreaming("HelloWorld/hello", req, headers);
     # ```
     #
     # + methodID - Remote service method ID
     # + payload - Request message. The message type varies with the remote service method parameter
     # + headers - Optional headers parameter. The header value are passed only if needed. The default value is `()`
-    # + return - A `stream<anydata>` or a `grpc:Error` when an error occurs while sending the request
+    # + return - A `stream<anydata, grpc:Error?>` or a `grpc:Error` when an error occurs while sending the request
     isolated remote function executeServerStreaming(string methodID, anydata payload, map<string|string[]> headers = {})
-                                    returns [stream<anydata>, map<string|string[]>]|Error {
+                                    returns [stream<anydata, Error?>, map<string|string[]>]|Error {
          return externExecuteServerStreaming(self, methodID, payload, headers);
     }
 
@@ -168,7 +168,7 @@ isolated function externExecuteSimpleRPC(Client clientEndpoint, string methodID,
 } external;
 
 isolated function externExecuteServerStreaming(Client clientEndpoint, string methodID, anydata payload,
-                map<string|string[]> headers) returns [stream<anydata>, map<string|string[]>]|Error = @java:Method {
+                map<string|string[]> headers) returns [stream<anydata, Error?>, map<string|string[]>]|Error = @java:Method {
     'class: "org.ballerinalang.net.grpc.nativeimpl.client.FunctionUtils"
 } external;
 

--- a/grpc-ballerina/tests/06_server_streaming_client.bal
+++ b/grpc-ballerina/tests/06_server_streaming_client.bal
@@ -53,7 +53,7 @@ public client class HelloWorld45Client {
         checkpanic self.grpcClient.initStub(self, ROOT_DESCRIPTOR_6, getDescriptorMap6());
     }
 
-    isolated remote function lotsOfReplies(string req) returns stream<anydata>|Error {
+    isolated remote function lotsOfReplies(string req) returns stream<anydata, Error?>|Error {
         
         var payload = check self.grpcClient->executeServerStreaming("grpcservices.HelloWorld45/lotsOfReplies", req);
         [stream<anydata>, map<string|string[]>][result, _] = payload;

--- a/grpc-ballerina/tests/23_server_streaming_with_record_client.bal
+++ b/grpc-ballerina/tests/23_server_streaming_with_record_client.bal
@@ -49,7 +49,7 @@ public client class helloWorldServerStreamingClient {
         checkpanic self.grpcClient.initStub(self, ROOT_DESCRIPTOR_23, getDescriptorMap23());
     }
 
-    isolated remote function lotsOfReplies(HelloRequest req) returns stream<anydata>|Error {
+    isolated remote function lotsOfReplies(HelloRequest req) returns stream<anydata, Error?>|Error {
         
         var payload = check self.grpcClient->executeServerStreaming("helloWorldServerStreaming/lotsOfReplies", req);
         [stream<anydata>, map<string|string[]>][result, _] = payload;

--- a/grpc-ballerina/tests/24_return_data_unary_client.bal
+++ b/grpc-ballerina/tests/24_return_data_unary_client.bal
@@ -348,7 +348,7 @@ public client class HelloWorld24Client {
         return {content: <SampleMsg24>result, headers: respHeaders};
     }
 
-    isolated remote function testRecordValueReturnStream(string req) returns stream<anydata>|Error {
+    isolated remote function testRecordValueReturnStream(string req) returns stream<anydata, Error?>|Error {
 
         var payload = check self.grpcClient->executeServerStreaming("HelloWorld24/testRecordValueReturnStream", req);
         [stream<anydata>, map<string|string[]>][result, _] = payload;

--- a/grpc-ballerina/tests/25_return_data_streaming_client.bal
+++ b/grpc-ballerina/tests/25_return_data_streaming_client.bal
@@ -55,7 +55,7 @@ public client class HelloWorld25Client {
 
         var payload = check self.grpcClient->executeServerStreaming("grpcservices.HelloWorld25/lotsOfReplies", req);
         [stream<anydata, Error?>, map<string|string[]>][result, _] = payload;
-        StringStream stringStream = new StringStream(anydataStream);
+        StringStream stringStream = new StringStream(result);
         return new stream<string, Error?>(stringStream);
     }
 

--- a/grpc-ballerina/tests/32_return_record_server_streaming_client.bal
+++ b/grpc-ballerina/tests/32_return_record_server_streaming_client.bal
@@ -85,15 +85,15 @@ public client class HelloWorld32Client {
         Error? result = self.grpcClient.initStub(self, ROOT_DESCRIPTOR_32, getDescriptorMap32());
     }
 
-    isolated remote function sayHello(SampleMsg32 req) returns stream<anydata>|Error {
+    isolated remote function sayHello(SampleMsg32 req) returns stream<anydata, Error?>|Error {
         var payload = check self.grpcClient->executeServerStreaming("HelloWorld32/sayHello", req);
-        [stream<anydata>, map<string|string[]>][result, _] = payload;
+        [stream<anydata, Error?>, map<string|string[]>][result, _] = payload;
         return result;
     }
 
     isolated remote function sayHelloContext(SampleMsg32 req) returns ContextSampleMsg32Stream|Error {
         var payload = check self.grpcClient->executeServerStreaming("HelloWorld32/sayHello", req);
-        [stream<anydata>, map<string|string[]>][result, headers] = payload;
+        [stream<anydata, Error?>, map<string|string[]>][result, headers] = payload;
         return {content: result, headers: headers};
     }
 }

--- a/grpc-native/src/main/java/org/ballerinalang/net/grpc/nativeimpl/streamingclient/FunctionUtils.java
+++ b/grpc-native/src/main/java/org/ballerinalang/net/grpc/nativeimpl/streamingclient/FunctionUtils.java
@@ -156,7 +156,7 @@ public class FunctionUtils {
      * Extern function to receive the server responses(either client streaming or bidi-streaming).
      *
      * @param streamingConnection streaming connection instance.
-     * @return In client streaming, return an `anydata` and in bidi-streaming, return a `stream<anydata>`.
+     * @return In streaming scenarios, return an `anydata`.
      */
     public static Object externReceive(BObject streamingConnection) {
 


### PR DESCRIPTION
## Purpose
$subject

## Approach
- Enable `grpc:Error?` in server stream
- Enable custom stream object in server stream

## Automation tests
 - Unit tests 
   > Yes

## Test environment
- macOS
- SLP9
- Java11