### PR TITLE
Fix unnecessary caller check in client and bidirectional streaming

### DIFF
--- a/grpc-ballerina/tests/26_return_data_client_streaming_service.bal
+++ b/grpc-ballerina/tests/26_return_data_client_streaming_service.bal
@@ -36,32 +36,6 @@ service "HelloWorld26" on ep26 {
     }
 }
 
-public client class HelloWorld26StringCaller {
-    private Caller caller;
-
-    public isolated function init(Caller caller) {
-        self.caller = caller;
-    }
-
-    public isolated function getId() returns int {
-        return self.caller.getId();
-    }
-    
-    isolated remote function sendString(string response) returns Error? {
-        return self.caller->send(response);
-    }
-    isolated remote function sendContextString(ContextString response) returns Error? {
-        return self.caller->send(response);
-    }
-    
-    isolated remote function sendError(Error response) returns Error? {
-        return self.caller->sendError(response);
-    }
-
-    isolated remote function complete() returns Error? {
-        return self.caller->complete();
-    }
-}
 
 const string ROOT_DESCRIPTOR_26 = "0A2532365F72657475726E5F646174615F636C69656E745F73747265616D696E672E70726F746F120C6772706373657276696365731A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F325F0A0C48656C6C6F576F726C643236124F0A0F6C6F74734F664772656574696E6773121C2E676F6F676C652E70726F746F6275662E537472696E6756616C75651A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C75652801620670726F746F33";
 isolated function getDescriptorMap26() returns map<string> {

--- a/grpc-ballerina/tests/27_return_data_bidirectional_streaming_service.bal
+++ b/grpc-ballerina/tests/27_return_data_bidirectional_streaming_service.bal
@@ -42,30 +42,6 @@ public type ChatMessage27 record {|
 
 |};
 
-public client class ChatFromReturnStringCaller {
-    private Caller caller;
-
-    public isolated function init(Caller caller) {
-        self.caller = caller;
-    }
-
-    public isolated function getId() returns int {
-        return self.caller.getId();
-    }
-
-    isolated remote function sendChatMessage27(ChatMessage27 response) returns Error? {
-        return self.caller->send(response);
-    }
-
-    isolated remote function sendError(Error response) returns Error? {
-        return self.caller->sendError(response);
-    }
-
-    isolated remote function complete() returns Error? {
-        return self.caller->complete();
-    }
-}
-
 const string ROOT_DESCRIPTOR_27 = "0A2832375F6269646972656374696F6E616C5F73747265616D696E675F736572766963652E70726F746F1A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F223D0A0D436861744D657373616765323712120A046E616D6518012001280952046E616D6512180A076D65737361676518022001280952076D657373616765324A0A0E4368617446726F6D52657475726E12380A0463686174120E2E436861744D65737361676532371A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C756528013001620670726F746F33";
 isolated function getDescriptorMap27() returns map<string> {
     return {

--- a/grpc-native/src/main/java/org/ballerinalang/net/grpc/GrpcConstants.java
+++ b/grpc-native/src/main/java/org/ballerinalang/net/grpc/GrpcConstants.java
@@ -73,6 +73,7 @@ public class GrpcConstants {
 
     //client side endpoint constants
     public static final String CLIENT_ENDPOINT_TYPE = "Client";
+    public static final String CLIENT_ENDPOINT_RESPONSE_OBSERVER = "ResponseObserver";
     public static final String CLIENT_CONNECTOR = "ClientConnector";
     public static final String ENDPOINT_URL = "url";
     public static final String MESSAGE_HEADERS = "MessageHeaders";

--- a/grpc-native/src/main/java/org/ballerinalang/net/grpc/MessageUtils.java
+++ b/grpc-native/src/main/java/org/ballerinalang/net/grpc/MessageUtils.java
@@ -109,6 +109,9 @@ public class MessageUtils {
     }
 
     public static StreamObserver getResponseObserver(BObject refType) {
+        if (refType instanceof StreamObserver) {
+            return ((StreamObserver) refType);
+        }
         Object observerObject = refType.getNativeData(GrpcConstants.RESPONSE_OBSERVER);
         if (observerObject instanceof StreamObserver) {
             return ((StreamObserver) observerObject);

--- a/grpc-native/src/main/java/org/ballerinalang/net/grpc/listener/StreamingServerCallHandler.java
+++ b/grpc-native/src/main/java/org/ballerinalang/net/grpc/listener/StreamingServerCallHandler.java
@@ -40,7 +40,7 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static org.ballerinalang.net.grpc.GrpcConstants.CLIENT_ENDPOINT_TYPE;
+import static org.ballerinalang.net.grpc.GrpcConstants.CLIENT_ENDPOINT_RESPONSE_OBSERVER;
 import static org.ballerinalang.net.grpc.GrpcConstants.COMPLETED_MESSAGE;
 import static org.ballerinalang.net.grpc.GrpcConstants.ITERATOR_OBJECT_NAME;
 import static org.ballerinalang.net.grpc.GrpcConstants.MESSAGE_QUEUE;
@@ -79,7 +79,7 @@ public class StreamingServerCallHandler extends ServerCallHandler {
         BObject streamIterator = ValueCreator.createObjectValue(getModule(), ITERATOR_OBJECT_NAME, new Object[1]);
         BlockingQueue<Message> messageQueue = new LinkedBlockingQueue<>();
         streamIterator.addNativeData(MESSAGE_QUEUE, messageQueue);
-        streamIterator.addNativeData(CLIENT_ENDPOINT_TYPE, getConnectionParameter(resource, responseObserver));
+        streamIterator.addNativeData(CLIENT_ENDPOINT_RESPONSE_OBSERVER, responseObserver);
         BStream requestStream = ValueCreator.createStreamValue(TypeCreator.createStreamType(inputType),
                 streamIterator);
         onStreamInvoke(resource, requestStream, call.getHeaders(), responseObserver, context);

--- a/grpc-native/src/main/java/org/ballerinalang/net/grpc/nativeimpl/serviceendpoint/FunctionUtils.java
+++ b/grpc-native/src/main/java/org/ballerinalang/net/grpc/nativeimpl/serviceendpoint/FunctionUtils.java
@@ -46,7 +46,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Semaphore;
 
 import static org.ballerinalang.net.grpc.GrpcConstants.ANN_SERVICE_DESCRIPTOR_FQN;
-import static org.ballerinalang.net.grpc.GrpcConstants.CLIENT_ENDPOINT_TYPE;
+import static org.ballerinalang.net.grpc.GrpcConstants.CLIENT_ENDPOINT_RESPONSE_OBSERVER;
 import static org.ballerinalang.net.grpc.GrpcConstants.ERROR_MESSAGE;
 import static org.ballerinalang.net.grpc.GrpcConstants.MESSAGE_QUEUE;
 import static org.ballerinalang.net.grpc.GrpcConstants.SERVER_CONNECTOR;
@@ -183,7 +183,7 @@ public class FunctionUtils  extends AbstractGrpcNativeFunction  {
 
     public static Object closeStream(Environment env, BObject streamIterator) {
         Semaphore listenerSemaphore = (Semaphore) streamIterator.getNativeData(MESSAGE_QUEUE);
-        BObject clientEndpoint = (BObject) streamIterator.getNativeData(CLIENT_ENDPOINT_TYPE);
+        BObject clientEndpoint = (BObject) streamIterator.getNativeData(CLIENT_ENDPOINT_RESPONSE_OBSERVER);
         Object errorVal = streamIterator.getNativeData(ERROR_MESSAGE);
         BError returnError;
         if (errorVal instanceof BError) {


### PR DESCRIPTION
## Purpose
$subject

## Approach
- Set response observer instead of the custom caller
- Enable additional logic to check the received object is a response observer or not. Then check the same object is a client object or not.

## Automation tests
 - Unit tests 
   >Yes

## Test environment
- macOS
- Swan Lake Alpha 01
- Java11