### PR TITLE
Fix protobuf tools issues

### DIFF
--- a/grpc-native/src/main/resources/templates/client_stub_file.mustache
+++ b/grpc-native/src/main/resources/templates/client_stub_file.mustache
@@ -1,9 +1,8 @@
 {{#if stubList}}import ballerina/grpc;
 {{/if}}{{#stubList}}
-{{> stub}}
-{{/stubList}}{{#each messageMap}}
-{{> message}}{{/each}}{{#each valueTypeMap}}
-{{> content_context}}{{/each}}
+{{> stub}}{{#each valueTypeMap}}
+{{> content_context}}{{/each}}{{/stubList}}{{#each messageMap}}
+{{> message}}{{/each}}
 {{#enumList}}
 {{> enum}}{{/enumList}}{{#if rootDescriptor}}
 const string ROOT_DESCRIPTOR = "{{rootDescriptor}}";

--- a/grpc-native/src/main/resources/templates/service_sample.mustache
+++ b/grpc-native/src/main/resources/templates/service_sample.mustache
@@ -17,7 +17,7 @@ service "{{serviceName}}" on ep {
     remote function {{methodName}}({{#isNotNull inputType}}{{inputType}} value{{/isNotNull}}) returns stream<{{#isNotNull outputType}}{{outputType}}{{/isNotNull}}{{~#isNull outputType}}record {}{{/isNull}},error>|error {
     // Implementation goes here.
     }{{/serverStreamingFunctions}}{{#bidiStreamingFunctions}}
-    remote function {{methodName}}({{#isNotNull inputType}}{{inputType}} value{{/isNotNull}}) returns stream<{{#isNotNull outputType}}{{outputType}}{{/isNotNull}}{{~#isNull outputType}}record {}{{/isNull}},error>|error {
+    remote function {{methodName}}(stream<{{#isNotNull inputType}}{{inputType}}{{/isNotNull}}{{~#isNull inputType}}record {}{{/isNull}},error> clientStream) returns stream<{{#isNotNull outputType}}{{outputType}}{{/isNotNull}}{{~#isNull outputType}}record {}{{/isNull}},error>|error {
     // Implementation goes here.
     }{{/bidiStreamingFunctions}}
 }

--- a/grpc-native/src/main/resources/templates/service_sample.mustache
+++ b/grpc-native/src/main/resources/templates/service_sample.mustache
@@ -8,16 +8,16 @@ listener grpc:Listener ep = new (9090);
 }
 service "{{serviceName}}" on ep {
     {{#clientStreamingFunctions}}
-    remote function {{methodName}}(stream<{{#isNotNull inputType}}{{inputType}}{{/isNotNull}}{{~#isNull inputType}}record {}{{/isNull}},error> clientStream) returns {{#isNotNull outputType}}{{outputType}}|{{/isNotNull}}error {
+    remote function {{methodName}}(stream<{{#isNotNull inputType}}{{inputType}}{{/isNotNull}}{{~#isNull inputType}}record {}{{/isNull}}, grpc:Error?> clientStream) returns {{#isNotNull outputType}}{{outputType}}|{{/isNotNull}}error {
         // Implementation goes here.
     }{{/clientStreamingFunctions}}{{#unaryFunctions}}
     remote function {{methodName}}({{#isNotNull inputType}}{{inputType}} value{{/isNotNull}}) returns {{#isNotNull outputType}}{{outputType}}|{{/isNotNull}}error {
         // Implementation goes here.
     }{{/unaryFunctions}}{{#serverStreamingFunctions}}
-    remote function {{methodName}}({{#isNotNull inputType}}{{inputType}} value{{/isNotNull}}) returns stream<{{#isNotNull outputType}}{{outputType}}{{/isNotNull}}{{~#isNull outputType}}record {}{{/isNull}},error>|error {
+    remote function {{methodName}}({{#isNotNull inputType}}{{inputType}} value{{/isNotNull}}) returns stream<{{#isNotNull outputType}}{{outputType}}{{/isNotNull}}{{~#isNull outputType}}record {}{{/isNull}}, grpc:Error?>|error {
     // Implementation goes here.
     }{{/serverStreamingFunctions}}{{#bidiStreamingFunctions}}
-    remote function {{methodName}}(stream<{{#isNotNull inputType}}{{inputType}}{{/isNotNull}}{{~#isNull inputType}}record {}{{/isNull}},error> clientStream) returns stream<{{#isNotNull outputType}}{{outputType}}{{/isNotNull}}{{~#isNull outputType}}record {}{{/isNull}},error>|error {
+    remote function {{methodName}}(stream<{{#isNotNull inputType}}{{inputType}}{{/isNotNull}}{{~#isNull inputType}}record {}{{/isNull}}, grpc:Error?> clientStream) returns stream<{{#isNotNull outputType}}{{outputType}}{{/isNotNull}}{{~#isNull outputType}}record {}{{/isNull}}, grpc:Error?>|error {
     // Implementation goes here.
     }{{/bidiStreamingFunctions}}
 }


### PR DESCRIPTION
## Purpose
Resolves: ballerina-platform/ballerina-standard-library#851

Client

- [x] Context is not generated at the client-side when I enable the client mode.
- [x] The main function of the client contains the HelloWorldBlockingClient that needs to be corrected as HelloWorldClient.
- [x] The API returns a Context|grpc:Error?. It would be better to have it without null as Context|grpc:Error.
- [x] Need to have checkpanic the client init because recent changes to the init return an error as below example 01.
- [x] The name LotsOfGreetingsexecuteClientStreaming need to be corrected.
- [x] Need returns grpc:Error? in the init function.

Server

- [x] Bidi-streaming service param should be a stream.
- [x] Custom streaming client receive() should return an error because the end of the stream is an error. So, we need to remove the check as example 03.