### PR TITLE
Change ballerina archive extension to bala

### DIFF
--- a/grpc-ballerina/Dependencies.toml
+++ b/grpc-ballerina/Dependencies.toml
@@ -1,7 +1,7 @@
 [[dependency]]
 org = "ballerina"
 name = "runtime"
-version = "@stdlib.runtime.version@
+version = "@stdlib.runtime.version@"
 
 [[dependency]]
 org = "ballerina"

--- a/grpc-ballerina/build.gradle
+++ b/grpc-ballerina/build.gradle
@@ -133,8 +133,8 @@ task copyStdlibs(type: Copy) {
     /* Standard Libraries */
     configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         def artifactExtractedPath = "${buildDir}/target/extracted-distributions/" + artifact.name + "-zip"
-        into("repo/balo") {
-            from "${artifactExtractedPath}/balo/"
+        into("repo/bala") {
+            from "${artifactExtractedPath}/bala/"
         }
         into("repo/cache") {
             from "${artifactExtractedPath}/cache"
@@ -277,8 +277,8 @@ task ballerinaBuild {
             }
         }
         copy {
-            from file("$project.projectDir/target/balo")
-            into file("$artifactCacheParent/balo/${packageOrg}/${packageName}/${tomlVersion}")
+            from file("$project.projectDir/target/bala")
+            into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}")
         }
         copy {
             from file("$project.projectDir/target/cache")


### PR DESCRIPTION
## Purpose
> Renames the extension of the package distribution file from balo to bala 
> Fixes ballerina-platform/ballerina-lang#28476 