### PR TITLE
Enable Publishing to Ballerina Central on Release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ jobs:
                 with:
                     java-version: 11
             -   name: Set version env variable
-                run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | cut -d- -f1)" >> $GITHUB_ENV
+                run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV
             -   name: Pre release depenency version update
                 env:
                     GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -207,24 +207,3 @@ release {
 task build {
     dependsOn('grpc-ballerina:build')
 }
-
-task codeCoverageReport(type: JacocoReport) {
-    executionData fileTree(project.rootDir.absolutePath).include("**/build/coverage-reports/*.exec")
-
-    subprojects.each {
-        sourceSets it.sourceSets.main
-    }
-
-    reports {
-        xml.enabled = true
-        html.enabled = true
-        csv.enabled = true
-        xml.destination = new File("${buildDir}/reports/jacoco/report.xml")
-        html.destination = new File("${buildDir}/reports/jacoco/report.html")
-        csv.destination = new File("${buildDir}/reports/jacoco/report.csv")
-    }
-
-    onlyIf = {
-        true
-    }
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=org.ballerinalang
-version=0.7.7-SNAPSHOT
+version=0.8.0-alpha2-SNAPSHOT
 #dependency versions
 ballerinaLangVersion=2.0.0-alpha3-SNAPSHOT
 ballerinaTomlParserVersion=1.2.2

--- a/grpc-ballerina/build.gradle
+++ b/grpc-ballerina/build.gradle
@@ -19,6 +19,24 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 description = 'Ballerina - gRPC Ballerina Generator'
 
+def packageName = "grpc"
+def packageOrg = "ballerina"
+def tomlVersion = project.version.replace("-SNAPSHOT", "")
+def ballerinaConfigFile = new File("$project.projectDir/Ballerina.toml")
+def ballerinaDependencyFile = new File("$project.projectDir/Dependencies.toml")
+def artifactBallerinaDocs = file("$project.projectDir/build/docs_parent/")
+def artifactCacheParent = file("$project.projectDir/build/cache_parent/")
+def artifactLibParent = file("$project.projectDir/build/lib_parent/")
+def artifactCodeCoverageReport = file("$project.projectDir/target/cache/tests_cache/coverage/ballerina.exec")
+def artifactTestableJar = file("${project.projectDir}/target/cache/${packageOrg}/${packageName}/${tomlVersion}/java11/")
+def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
+// external jar file which need to pack to distribution
+def externalGoogleProtosCommonJar = file("$project.projectDir/lib/proto-google-common-protos-${protoGoogleCommonsVersion}.jar")
+def targetNativeJar = file("$project.rootDir/${packageName}-native/build/libs/${packageName}-native-${project.version}.jar")
+def distributionBinPath = project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
+def originalConfig = ballerinaConfigFile.text
+def originalDependencyConfig = ballerinaDependencyFile.text
+
 configurations {
     jbalTools
     externalJars
@@ -28,7 +46,7 @@ dependencies {
     jbalTools("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
         transitive = false
     }
-    compile project(':grpc-native')
+    compile project(":${packageName}-native")
 
     externalJars (group: 'org.ballerinalang', name: 'http-native', version: "${stdlibHttpVersion}") {
         transitive = false
@@ -106,7 +124,6 @@ task copyToLib(type: Copy) {
 }
 
 task unpackJballerinaTools(type: Copy) {
-    dependsOn(copyToLib)
     configurations.jbalTools.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         from zipTree(artifact.getFile())
         into new File("${buildDir}/target/extracted-distributions", "jballerina-tools-zip")
@@ -114,7 +131,6 @@ task unpackJballerinaTools(type: Copy) {
 }
 
 task unpackStdLibs() {
-    dependsOn(unpackJballerinaTools)
     doLast {
         configurations.ballerinaStdLibs.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             copy {
@@ -126,7 +142,6 @@ task unpackStdLibs() {
 }
 
 task copyStdlibs(type: Copy) {
-    dependsOn(unpackStdLibs)
     def ballerinaDist = "build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
     into ballerinaDist
 
@@ -142,32 +157,15 @@ task copyStdlibs(type: Copy) {
     }
 }
 
-def packageName = "grpc"
-def packageOrg = "ballerina"
-def ballerinaConfigFile = new File("$project.projectDir/Ballerina.toml")
-def ballerinaDependencyFile = new File("$project.projectDir/Dependencies.toml")
-def artifactBallerinaDocs = file("$project.projectDir/build/docs_parent/")
-def artifactCacheParent = file("$project.projectDir/build/cache_parent/")
-def artifactLibParent = file("$project.projectDir/build/lib_parent/")
-def artifactCodeCoverageReport = file("$project.projectDir/target/cache/tests_cache/coverage/ballerina.exec")
-def tomlVersion = project.version.split("-")[0]
-def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
-// external jar file which need to pack to distribution
-def externalGoogleProtosCommonJar = file("$project.projectDir/lib/proto-google-common-protos-${protoGoogleCommonsVersion}.jar")
-def targetNativeJar = file("$project.rootDir/${packageName}-native/build/libs/${packageName}-native-${project.version}.jar")
-def distributionBinPath = project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
-def originalConfig = ballerinaConfigFile.text
-def originalDependencyConfig = ballerinaDependencyFile.text
-
-task updateTomlFile {
+task updateTomlVersions {
     doLast {
-        def stdlibDependentRuntimeVersion = project.stdlibRuntimeVersion.split("-")[0]
-        def stdlibDependentCryptoVersion = project.stdlibCryptoVersion.split("-")[0]
-        def stdlibDependentHttpVersion = project.stdlibHttpVersion.split("-")[0]
-        def stdlibDependentAuthVersion = project.stdlibOAuth2Version.split("-")[0]
-        def stdlibDependentJwtVersion = project.stdlibJwtVersion.split("-")[0]
-        def stdlibDependentOAuth2Version = project.stdlibOAuth2Version.split("-")[0]
-        def stdlibDependentRegexVersion = project.stdlibRegexVersion.split("-")[0]
+        def stdlibDependentRuntimeVersion = project.stdlibRuntimeVersion.replace("-SNAPSHOT", "")
+        def stdlibDependentCryptoVersion = project.stdlibCryptoVersion.replace("-SNAPSHOT", "")
+        def stdlibDependentHttpVersion = project.stdlibHttpVersion.replace("-SNAPSHOT", "")
+        def stdlibDependentAuthVersion = project.stdlibOAuth2Version.replace("-SNAPSHOT", "")
+        def stdlibDependentJwtVersion = project.stdlibJwtVersion.replace("-SNAPSHOT", "")
+        def stdlibDependentOAuth2Version = project.stdlibOAuth2Version.replace("-SNAPSHOT", "")
+        def stdlibDependentRegexVersion = project.stdlibRegexVersion.replace("-SNAPSHOT", "")
         def stdlibDependentNettyVersion = project.nettyVersion
 
         def newConfig = ballerinaConfigFile.text.replace("@project.version@", project.version)
@@ -194,16 +192,11 @@ task revertTomlFile {
     }
 }
 
-assemble {
-    dependsOn(copyStdlibs)
-    dependsOn(":grpc-native:build")
-    dependsOn(":grpc-test-utils:build")
-}
-
 def groupParams = ""
 def disableGroups = ""
 def debugParams = ""
 def balJavaDebugParam = ""
+def testParams = ""
 
 task initializeVariables {
     if (project.hasProperty("groups")) {
@@ -218,14 +211,26 @@ task initializeVariables {
     if (project.hasProperty("balJavaDebug")) {
         balJavaDebugParam = "BAL_JAVA_DEBUG=${project.findProperty("balJavaDebug")}"
     }
+    gradle.taskGraph.whenReady { graph ->
+        if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish"))  {
+            ballerinaTest.enabled = false
+        }
+
+        if (graph.hasTask(":${packageName}-ballerina:test")) {
+            testParams = "--code-coverage --includes=*"
+        } else {
+            testParams = "--skip-tests"
+        }
+
+        if (graph.hasTask(":${packageName}-ballerina:publish")) {
+            ballerinaPublish.enabled = true
+        } else {
+            ballerinaPublish.enabled = false
+        }
+    }
 }
 
 task ballerinaTest {
-    dependsOn(assemble)
-    dependsOn(updateTomlFile)
-    dependsOn(initializeVariables)
-    finalizedBy(revertTomlFile)
-
     def privateKey = "tests/certsandkeys/private.key"
     def publicCert = "tests/certsandkeys/public.crt"
     def keyStore = "tests/certsandkeys/ballerinaKeystore.p12"
@@ -245,26 +250,7 @@ task ballerinaTest {
     }
 }
 
-test {
-    dependsOn(ballerinaTest)
-}
-
 task ballerinaBuild {
-    dependsOn(test)
-    dependsOn(updateTomlFile)
-    dependsOn(initializeVariables)
-    finalizedBy(revertTomlFile)
-
-    def testParams = "--skip-tests"
-    gradle.taskGraph.whenReady { graph ->
-        if (graph.hasTask(':grpc-ballerina:build') || graph.hasTask(':grpc-ballerina:publish')) {
-            ballerinaTest.enabled = false
-        }
-        if (graph.hasTask(':grpc-ballerina:test')) {
-            testParams = "--code-coverage --includes=*"
-        }
-    }
-
     doLast {
         // Build and populate caches
         exec {
@@ -287,20 +273,6 @@ task ballerinaBuild {
             into file("$artifactCacheParent/cache/")
         }
 
-        // Publish to central
-        if (!project.version.endsWith('-SNAPSHOT') && ballerinaCentralAccessToken != null && project.hasProperty("publishToCentral")) {
-            println("Publishing to the ballerina central..")
-            exec {
-                workingDir project.projectDir
-                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
-                } else {
-                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
-                }
-            }
-
-        }
         // Doc creation and packing
         exec {
             workingDir project.projectDir
@@ -330,8 +302,22 @@ task ballerinaBuild {
     outputs.dir artifactLibParent
 }
 
-build {
-    dependsOn(ballerinaBuild)
+task ballerinaPublish {
+    doLast {
+        if (ballerinaCentralAccessToken != null) {
+            println("Publishing to the ballerina central..")
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
+                }
+            }
+
+        }
+    }
 }
 
 task createArtifactZip(type: Zip) {
@@ -355,7 +341,7 @@ publishing {
     repositories {
         maven {
             name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/ballerina-platform/module-ballerina-grpc")
+            url = uri("https://maven.pkg.github.com/ballerina-platform/module-${packageOrg}-${packageName}")
             credentials {
                 username = System.getenv("packageUser")
                 password = System.getenv("packagePAT")
@@ -363,3 +349,25 @@ publishing {
         }
     }
 }
+
+unpackJballerinaTools.dependsOn copyToLib
+unpackStdLibs.dependsOn unpackJballerinaTools
+copyStdlibs.dependsOn unpackStdLibs
+updateTomlVersions.dependsOn copyStdlibs
+
+ballerinaTest.finalizedBy revertTomlFile
+ballerinaTest.dependsOn initializeVariables
+ballerinaTest.dependsOn updateTomlVersions
+ballerinaTest.dependsOn ":${packageName}-native:build"
+ballerinaTest.dependsOn ":${packageName}-test-utils:build"
+test.dependsOn ballerinaTest
+
+ballerinaBuild.dependsOn test
+ballerinaBuild.finalizedBy revertTomlFile
+ballerinaBuild.dependsOn initializeVariables
+ballerinaBuild.dependsOn updateTomlVersions
+ballerinaBuild.dependsOn ":${packageName}-native:build"
+build.dependsOn ballerinaBuild
+
+ballerinaPublish.dependsOn ballerinaBuild
+publish.dependsOn ballerinaPublish


### PR DESCRIPTION
## Purpose

Related issue : ballerina-platform/ballerina-standard-library#957

- Improve the build script
- Enable publishing to Ballerina Central when gradle publish is called
- Bump the version to <next_minor_version>-alpha2-SNAPSHOT
- Remove unnecessary gradle tasks
