### PR TITLE
Generate Codecov Report

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -39,6 +39,8 @@ jobs:
                     name: Code Coverage JSON
                     path: grpc-ballerina/target/report/test_results.json
                     if-no-files-found: ignore
+            -   name: Generate CodeCov Report
+                uses: codecov/codecov-action@v1
             -   name: Dispatch Dependent Module Builds
                 if: github.event.action != 'stdlib-publish-snapshot'
                 run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,7 +33,8 @@ jobs:
                     name: Code Coverage JSON
                     path: grpc-ballerina/target/report/test_results.json
                     if-no-files-found: ignore
-
+            -   name: Generate CodeCov Report
+                uses: codecov/codecov-action@v1
     windows-build:
         runs-on: windows-latest
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,7 @@ jobs:
                     if-no-files-found: ignore
             -   name: Generate CodeCov Report
                 uses: codecov/codecov-action@v1
+                
     windows-build:
         runs-on: windows-latest
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,4 +7,3 @@ ignore:
 
 codecov:
   require_ci_to_pass: no
-  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+fixes:
+
+ignore:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,2 @@
 fixes:
   - "ballerina/grpc/*/::grpc-ballerina/"
-

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,6 @@
 fixes:
   - "ballerina/grpc/*/::grpc-ballerina/"
+
+ignore:
+  - "**/tests"
+  - "grpc-test-utils"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,2 @@
 fixes:
-
-ignore:
+  - "ballerina/grpc/*/::grpc-ballerina/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ fixes:
 ignore:
   - "**/tests"
   - "grpc-test-utils"
+
+codecov:
+  require_ci_to_pass: no
+  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 fixes:
   - "ballerina/grpc/*/::grpc-ballerina/"
+


### PR DESCRIPTION
## Purpose

- Introducing Codecov code coverage report publishing to the `grpc` repository

## Goals

- Publishing the testerina generated code coverage xml to Codecov triggered via GitHub action of PR.

## Approach

- A new job is inserted to Pull request and Build GitHub actions that publishes the XML report to Codecov.
- These jobs trigger on push or pull request and CodeCov generates a descriptive code coverage report.
- Codecov also adds comments to any PR made based on the code coverage changes between commits

## Test environment

- Ubuntu 20.04
