### PR TITLE
Remove io:sprintf and remove previous coverage build config

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -33,12 +33,6 @@ jobs:
                     name: Ballerina Internal Log
                     path: grpc-ballerina/ballerina-internal.log
                     if-no-files-found: ignore
-            -   name: Archive Code Coverage JSON
-                uses: actions/upload-artifact@v2
-                with:
-                    name: Code Coverage JSON
-                    path: grpc-ballerina/target/report/test_results.json
-                    if-no-files-found: ignore
             -   name: Generate CodeCov Report
                 uses: codecov/codecov-action@v1
             -   name: Dispatch Dependent Module Builds

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -27,12 +27,6 @@ jobs:
                     name: Ballerina Internal Log
                     path: grpc-ballerina/ballerina-internal.log
                     if-no-files-found: ignore
-            -   name: Archive Code Coverage JSON
-                uses: actions/upload-artifact@v2
-                with:
-                    name: Code Coverage JSON
-                    path: grpc-ballerina/target/report/test_results.json
-                    if-no-files-found: ignore
             -   name: Generate CodeCov Report
                 uses: codecov/codecov-action@v1
                 

--- a/grpc-ballerina/build.gradle
+++ b/grpc-ballerina/build.gradle
@@ -27,8 +27,6 @@ def ballerinaDependencyFile = new File("$project.projectDir/Dependencies.toml")
 def artifactBallerinaDocs = file("$project.projectDir/build/docs_parent/")
 def artifactCacheParent = file("$project.projectDir/build/cache_parent/")
 def artifactLibParent = file("$project.projectDir/build/lib_parent/")
-def artifactCodeCoverageReport = file("$project.projectDir/target/cache/tests_cache/coverage/ballerina.exec")
-def artifactTestableJar = file("${project.projectDir}/target/cache/${packageOrg}/${packageName}/${tomlVersion}/java11/")
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 // external jar file which need to pack to distribution
 def externalGoogleProtosCommonJar = file("$project.projectDir/lib/proto-google-common-protos-${protoGoogleCommonsVersion}.jar")
@@ -333,16 +331,10 @@ task createArtifactZip(type: Zip) {
     from ballerinaBuild
 }
 
-
-def getCheckedOutGitCommitHash() {
-    'git rev-parse --verify --short HEAD'.execute().text.trim()
-}
-
 publishing {
     publications {
         maven(MavenPublication) {
             artifact source: createArtifactZip, extension: 'zip'
-            artifact source: artifactCodeCoverageReport, classifier: 'jacoco'
         }
     }
 

--- a/grpc-ballerina/tests/01_advanced_type_client.bal
+++ b/grpc-ballerina/tests/01_advanced_type_client.bal
@@ -32,7 +32,7 @@ function testSendNestedStruct() {
     string|error unionResp = HelloWorld1BlockingEp->testInputNestedStruct(p);
     io:println(unionResp);
     if (unionResp is error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println(unionResp);
         test:assertEquals(unionResp, "Submitted name: Sam");
@@ -46,7 +46,7 @@ function testReceiveNestedStruct() {
     Person|Error unionResp = HelloWorld1BlockingEp->testOutputNestedStruct(name);
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println(unionResp.toString());
         test:assertEquals(unionResp.name, "Sam");
@@ -64,7 +64,7 @@ function testSendStructReceiveStruct() {
     StockQuote|Error unionResp = HelloWorld1BlockingEp->testInputStructOutputStruct(request);
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         test:assertEquals(unionResp.symbol, "WSO2");
@@ -81,7 +81,7 @@ function testSendNoReceiveStruct() {
     StockQuotes|Error unionResp = HelloWorld1BlockingEp->testNoInputOutputStruct();
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println(unionResp);
         test:assertEquals(unionResp.stock.length(), 2);
@@ -96,7 +96,7 @@ function testSendNoReceiveArray() {
     StockNames|Error unionResp = HelloWorld1BlockingEp->testNoInputOutputArray();
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -114,7 +114,7 @@ function testSendStructNoReceive() {
     Error? unionResp = HelloWorld1BlockingEp->testInputStructNoOutput(quote);
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     }
 }
 

--- a/grpc-ballerina/tests/02_array_field_type_client.bal
+++ b/grpc-ballerina/tests/02_array_field_type_client.bal
@@ -27,7 +27,7 @@ function testSendIntArray() {
     int|Error unionResp = HelloWorld2BlockingEp->testIntArrayInput(req);
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -43,7 +43,7 @@ function testSendStringArray() {
     string|Error unionResp = HelloWorld2BlockingEp->testStringArrayInput(req);
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -59,7 +59,7 @@ function testSendFloatArray() {
     float|Error unionResp = HelloWorld2BlockingEp->testFloatArrayInput(req);
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -75,7 +75,7 @@ function testSendBooleanArray() {
     boolean|Error unionResp = HelloWorld2BlockingEp->testBooleanArrayInput(req);
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -90,7 +90,7 @@ function testSendStructArray() {
     io:println(testStruct);
     string|Error unionResp = HelloWorld2BlockingEp->testStructArrayInput(testStruct);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -104,7 +104,7 @@ function testReceiveIntArray() {
     TestInt|Error unionResp = HelloWorld2BlockingEp->testIntArrayOutput();
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -122,7 +122,7 @@ function testReceiveStringArray() {
     io:println("testStringArrayOutput: No input:");
     TestString|Error unionResp = HelloWorld2BlockingEp->testStringArrayOutput();
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -139,7 +139,7 @@ function testReceiveFloatArray() {
     TestFloat|Error unionResp = HelloWorld2BlockingEp->testFloatArrayOutput();
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -156,7 +156,7 @@ function testReceiveBooleanArray() {
     TestBoolean|Error unionResp = HelloWorld2BlockingEp->testBooleanArrayOutput();
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -173,7 +173,7 @@ function testReceiveStructArray() {
     TestStruct|Error unionResp = HelloWorld2BlockingEp->testStructArrayOutput();
     io:println(unionResp);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);

--- a/grpc-ballerina/tests/03_bidirectional_streaming_client.bal
+++ b/grpc-ballerina/tests/03_bidirectional_streaming_client.bal
@@ -34,8 +34,7 @@ function testBidiStreaming() {
     // Executing unary non-blocking call registering server message listener.
     var res = chatEp->chat();
     if (res is Error) {
-        string msg = io:sprintf(ERROR_MSG_FORMAT, res.message());
-        io:println(msg);
+        io:println(string `Error from Connector: ${res.message()}`);
         return;
     } else {
         ep = res;
@@ -44,7 +43,7 @@ function testBidiStreaming() {
     ChatMessage mes1 = {name:"Sam", message:"Hi"};
     Error? connErr = ep->sendChatMessage(mes1);
     if (connErr is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, connErr.message()));
+        test:assertFail(string `Error from Connector: ${connErr.message()}`);
     }
 
     var responseMsg = ep->receiveString();
@@ -57,7 +56,7 @@ function testBidiStreaming() {
     ChatMessage mes2 = {name:"Sam", message:"GM"};
     connErr = ep->sendChatMessage(mes2);
     if (connErr is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, connErr.message()));
+        test:assertFail(string `Error from Connector: ${connErr.message()}`);
     }
 
     responseMsg = ep->receiveString();

--- a/grpc-ballerina/tests/05_invalid_resource_client.bal
+++ b/grpc-ballerina/tests/05_invalid_resource_client.bal
@@ -38,7 +38,7 @@ function testInvalidInputParameter() {
     string age = "";
     int|Error unionResp = helloWorld5BlockingEp->testInt(age);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf("Error from Connector: %s", unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client got response : ");
         test:assertEquals(unionResp, -1);

--- a/grpc-ballerina/tests/07_unary_blocking_client.bal
+++ b/grpc-ballerina/tests/07_unary_blocking_client.bal
@@ -26,7 +26,7 @@ function testUnaryBlockingClient() {
     string name = "WSO2";
     string|Error unionResp = helloWorld7BlockingEp->hello(name);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);
@@ -39,7 +39,7 @@ function testUnaryBlockingIntClient() {
     int age = 10;
     int|Error unionResp = helloWorld7BlockingEp->testInt(age);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client got response : ");
         io:println(unionResp);
@@ -52,7 +52,7 @@ function testUnaryBlockingFloatClient() {
     float salary = 1000.5;
     float|Error unionResp = helloWorld7BlockingEp->testFloat(salary);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client got response : ");
         io:println(unionResp);
@@ -65,7 +65,7 @@ function testUnaryBlockingBoolClient() {
     boolean isAvailable = false;
     boolean|Error unionResp = helloWorld7BlockingEp->testBoolean(isAvailable);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client got response : ");
         io:println(unionResp);
@@ -78,7 +78,7 @@ function testUnaryBlockingReceiveRecord() {
     string msg = "WSO2";
     Response|Error unionResp = helloWorld7BlockingEp->testResponseInsideMatch(msg);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client got response : ");
         io:println(unionResp);
@@ -91,7 +91,7 @@ function testUnaryBlockingStructClient() {
     Request req = {name:"Sam", age:10, message:"Testing."};
     Response|Error unionResp = helloWorld7BlockingEp->testStruct(req);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client got response : ");
         io:println(unionResp);

--- a/grpc-ballerina/tests/08_unary_client_with_headers.bal
+++ b/grpc-ballerina/tests/08_unary_client_with_headers.bal
@@ -28,7 +28,7 @@ function testHeadersInUnaryClient() {
     // Executing unary blocking call
     ContextString|Error unionResp = helloWorld8BlockingEp->helloContext(requestMessage);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         string result = unionResp.content;
         map<string|string[]> resHeaders = unionResp.headers;
@@ -47,7 +47,7 @@ function testHeadersInBlockingClient() returns Error? {
     // Executing unary blocking call
     ContextString|Error unionResp = helloWorld8BlockingEp->helloContext(requestMessage);
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         string result = unionResp.content;
         map<string|string[]> resHeaders = unionResp.headers;

--- a/grpc-ballerina/tests/09_grpc_secured_unary_client.bal
+++ b/grpc-ballerina/tests/09_grpc_secured_unary_client.bal
@@ -42,7 +42,7 @@ isolated function testUnarySecuredBlocking() {
 
     string|Error unionResp = helloWorld9BlockingEp->hello("WSO2");
     if (unionResp is Error) {
-        test:assertFail(io:sprintf("Error from Connector: %s", unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);

--- a/grpc-ballerina/tests/10_grpc_ssl_client.bal
+++ b/grpc-ballerina/tests/10_grpc_ssl_client.bal
@@ -31,7 +31,7 @@ isolated function testUnarySecuredBlockingWithCerts() {
 
     string|Error unionResp = helloWorldBlockingEp->hello("WSO2");
     if (unionResp is Error) {
-        test:assertFail(io:sprintf("Error from Connector: %s", unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         io:println("Client Got Response : ");
         io:println(unionResp);

--- a/grpc-ballerina/tests/11_grpc_byte_client.bal
+++ b/grpc-ballerina/tests/11_grpc_byte_client.bal
@@ -26,7 +26,7 @@ isolated function testByteArray() {
     byte[] bytes = statement.toBytes();
     var addResponse = blockingEp->checkBytes(bytes);
     if (addResponse is Error) {
-        test:assertFail(io:sprintf("Error from Connector: %s", addResponse.message()));
+        test:assertFail(string `Error from Connector: ${addResponse.message()}`);
     } else {
         test:assertEquals(addResponse, bytes);
     }
@@ -44,13 +44,12 @@ function testLargeByteArray() {
         if (resultBytes is byte[]) {
             var addResponse = blockingEp->checkBytes(resultBytes);
             if (addResponse is Error) {
-                test:assertFail(io:sprintf("Error from Connector: %s", addResponse.message()));
+                test:assertFail(string `Error from Connector: ${addResponse.message()}`);
             } else {
                 test:assertEquals(addResponse, resultBytes);
             }
         } else {
-            error err = resultBytes;
-            test:assertFail(io:sprintf("File read error: %s", err.message()));
+            test:assertFail(string `File read error: ${resultBytes.message()}`);
         }
     }
 }

--- a/grpc-ballerina/tests/12_grpc_enum_test_client.bal
+++ b/grpc-ballerina/tests/12_grpc_enum_test_client.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
 import ballerina/test;
 
 @test:Config {enable:true}
@@ -24,7 +23,7 @@ isolated function testSendAndReceiveEnum() {
     OrderInfo orderReq = { id:"100500", mode:r };
     var addResponse = blockingEp->testEnum(orderReq);
     if (addResponse is Error) {
-        test:assertFail(io:sprintf("Error from Connector: %s", addResponse.message()));
+        test:assertFail(string `Error from Connector: ${addResponse.message()}`);
     } else {
         test:assertEquals(addResponse, "r");
     }

--- a/grpc-ballerina/tests/15_grpc_oneof_field_client.bal
+++ b/grpc-ballerina/tests/15_grpc_oneof_field_client.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
 import ballerina/test;
 
 final OneofFieldServiceClient blockingEp = new("http://localhost:9105");
@@ -28,7 +27,7 @@ function testOneofFieldValue() {
     Request1 request = {first_name:"Sam", age:31};
     var result = blockingEp->hello(request);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result.message, "Hello Sam");
     }
@@ -39,7 +38,7 @@ function testDoubleFieldValue() {
     ZZZ zzz = {one_a:1.7976931348623157E308};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result?.one_a.toString(), "1.7976931348623157E308");
     }
@@ -50,7 +49,7 @@ function testFloatFieldValue() {
     ZZZ zzz = {one_b:3.4028235E38};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result?.one_b.toString(), "3.4028235E38");
     }
@@ -61,7 +60,7 @@ function testInt64FieldValue() {
     ZZZ zzz = {one_c:-9223372036854775808};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result?.one_c.toString(), "-9223372036854775808");
     }
@@ -72,7 +71,7 @@ function testUInt64FieldValue() {
     ZZZ zzz = {one_d:9223372036854775807};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result?.one_d.toString(), "9223372036854775807");
     }
@@ -83,7 +82,7 @@ function testInt32FieldValue() {
     ZZZ zzz = {one_e:-2147483648};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result?.one_e.toString(), "-2147483648");
     }
@@ -94,7 +93,7 @@ function testFixed64FieldValue() {
     ZZZ zzz = {one_f:9223372036854775807};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result?.one_f.toString(), "9223372036854775807");
     }
@@ -105,7 +104,7 @@ function testFixed32FieldValue() {
     ZZZ zzz = {one_g:2147483647};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result?.one_g.toString(), "2147483647");
     }
@@ -116,7 +115,7 @@ function testBolFieldValue() {
     ZZZ zzz = {one_h:true};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result?.one_h.toString(), "true");
     }
@@ -127,7 +126,7 @@ function testStringFieldValue() {
     ZZZ zzz = {one_i:"Testing"};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result?.one_i.toString(), "Testing");
     }
@@ -139,7 +138,7 @@ function testMessageFieldValue() {
     ZZZ zzz = {one_j:aaa};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result?.one_j?.aaa.toString(), "Testing");
     }
@@ -152,7 +151,7 @@ function testBytesFieldValue() {
     ZZZ zzz = {one_k:bytes};
     var result = blockingEp->testOneofField(zzz);
     if (result is Error) {
-         test:assertFail(io:sprintf("Error from Connector: %s ", result.message()));
+         test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         boolean bResp = result?.one_k == bytes;
         test:assertEquals(bResp.toString(), "true");

--- a/grpc-ballerina/tests/17_bidirectional_chat_client.bal
+++ b/grpc-ballerina/tests/17_bidirectional_chat_client.bal
@@ -15,7 +15,6 @@
 // under the License.
 // This is client implementation for bidirectional streaming scenario
 
-import ballerina/io;
 import ballerina/lang.runtime as runtime;
 import ballerina/test;
 
@@ -36,7 +35,7 @@ public function testBidiStreamingInChatClient() {
     // Executes unary non-blocking call registering server message listener.
     var res = chatEp->chat();
     if (res is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, res.message()));
+        test:assertFail(string `Error from Connector: ${res.message()}`);
         return;
     } else {
         ep = res;
@@ -46,7 +45,7 @@ public function testBidiStreamingInChatClient() {
     ChatMessage mes = {name: "Sam", message: "Hi"};
     Error? result = ep->send(mes);
     if (result is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, result.message()));
+        test:assertFail(string `Error from Connector: ${result.message()}`);
     }
 
     var responseMsg = ep->receive();

--- a/grpc-ballerina/tests/19_grpc_map_field_client.bal
+++ b/grpc-ballerina/tests/19_grpc_map_field_client.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
 import ballerina/test;
 
 final NegotiatorClient negotiatorEp = new ("http://localhost:9109");
@@ -32,7 +31,7 @@ function testMapFields() {
     };
     Error? publishMetrics = negotiatorEp->publishMetrics(request);
     if (publishMetrics is Error) {
-        test:assertFail(io:sprintf("Metrics publish failed: %s", publishMetrics.message()));
+        test:assertFail(string `Metrics publish failed: ${publishMetrics.message()}`);
     }
 }
 
@@ -41,7 +40,7 @@ function testOptionalFields() {
     HandshakeRequest request = {};
     HandshakeResponse|Error result = negotiatorEp->handshake(request);
     if (result is Error) {
-        test:assertFail(io:sprintf("Handshake failed: %s", result.message()));
+        test:assertFail(string `Handshake failed: ${result.message()}`);
     } else {
         test:assertEquals(result.id, "123456");
     }

--- a/grpc-ballerina/tests/19_grpc_map_service.bal
+++ b/grpc-ballerina/tests/19_grpc_map_service.bal
@@ -26,7 +26,7 @@ listener Listener negotiatorep = new (9109);
 service "Negotiator" on negotiatorep {
 
     isolated remote function handshake(NegotiatorHandshakeResponseCaller caller, HandshakeRequest value) {
-        log:print(io:sprintf("Handshake request: %s", value.toString()));
+        log:print(string `Handshake request: ${value.toString()}`);
 
         if (value.jsonStr != "") {
             error? sendError = caller->sendError(error InvalidArgumentError("jsonStr should be an empty string."));
@@ -58,14 +58,14 @@ service "Negotiator" on negotiatorep {
     }
 
     isolated remote function publishMetrics(NegotiatorNilCaller caller, MetricsPublishRequest value) {
-        log:print(io:sprintf("publishMetrics request: %s", value.toString()));
+        log:print(string `publishMetrics request: ${value.toString()}`);
 
         if (value.metrics.length() < 0) {
             error? sendError = caller->sendError(error InvalidArgumentError("metrics cannot be an empty array."));
             return;
         }
         foreach var metric in value.metrics {
-            log:print(io:sprintf("metric value: %s", metric.toString()));
+            log:print(string `metric value: ${metric.toString()}`);
             if (metric.tags.length() < 0) {
                 error? sendError = caller->sendError(error InvalidArgumentError("tags cannot be an empty array."));
                 return;
@@ -75,7 +75,7 @@ service "Negotiator" on negotiatorep {
     }
 
     isolated remote function publishTraces(NegotiatorNilCaller caller, TracesPublishRequest value) {
-        log:print(io:sprintf("publishTraces request: %s", value.toString()));
+        log:print(string `publishTraces request: ${value.toString()}`);
         error? complete = caller->complete();
         io:println(complete);
     }

--- a/grpc-ballerina/tests/20_unary_client_for_anonymous_service.bal
+++ b/grpc-ballerina/tests/20_unary_client_for_anonymous_service.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
 import ballerina/log;
 import ballerina/test;
 
@@ -45,7 +44,7 @@ function testAnonymousServiceWithBlockingClient() {
     // Executing unary blocking call
     [string, map<string|string[]>]|Error unionResp = helloWorld20BlockingEp->hello("WSO2");
     if (unionResp is Error) {
-        test:assertFail(io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(string `Error from Connector: ${unionResp.message()}`);
     } else {
         string result = "";
         [result, _] = unionResp;

--- a/grpc-ballerina/tests/21_grpc_gzip_encoding_client.bal
+++ b/grpc-ballerina/tests/21_grpc_gzip_encoding_client.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
 import ballerina/test;
 
 @test:Config {enable:true}
@@ -27,7 +26,7 @@ isolated function testGzipEncoding() {
     ContextOrder reqOrder = {content: 'order, headers: headers};
     string|error result = OrderMgtBlockingEp->addOrder(reqOrder);
     if (result is error) {
-        test:assertFail(io:sprintf("gzip encoding failed: %s", result.message()));
+        test:assertFail(string `Error from Connector: ${result.message()}`);
     } else {
         test:assertEquals(result, "Order is added 101");
     }

--- a/grpc-ballerina/tests/24_return_data_unary_client.bal
+++ b/grpc-ballerina/tests/24_return_data_unary_client.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
 import ballerina/test;
 import ballerina/lang.'string as langstring;
 
@@ -23,7 +22,7 @@ public function testStringValueReturn() {
     HelloWorld24Client helloWorldBlockingEp = new ("http://localhost:9114");
     var unionResp = helloWorldBlockingEp->testStringValueReturn("WSO2");
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         test:assertEquals(unionResp, "WSO2");
     }
@@ -35,7 +34,7 @@ public function testFloatValueReturn() {
     float n = 4.5;
     var unionResp = helloWorldBlockingEp->testFloatValueReturn(n);
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         test:assertEquals(unionResp, n);
     }
@@ -47,7 +46,7 @@ public function testDoubleValueReturn() {
     float n = 4.5;
     var unionResp = helloWorldBlockingEp->testDoubleValueReturn(n);
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         test:assertEquals(unionResp, n);
     }
@@ -59,7 +58,7 @@ public function testInt64ValueReturn() {
     int n = 45;
     var unionResp = helloWorldBlockingEp->testInt64ValueReturn(n);
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         test:assertEquals(unionResp, n);
     }
@@ -71,7 +70,7 @@ public function testBoolValueReturn() {
     boolean b = true;
     var unionResp = helloWorldBlockingEp->testBoolValueReturn(b);
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         test:assertTrue(unionResp);
     }
@@ -83,7 +82,7 @@ public function testBytesValueReturn() {
     string s = "Ballerina";
     var unionResp = helloWorldBlockingEp->testBytesValueReturn(s.toBytes());
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         string|error returnedString = langstring:fromBytes(unionResp);
         if (returnedString is string) {
@@ -99,7 +98,7 @@ public function testRecordValueReturn() {
     HelloWorld24Client helloWorldBlockingEp = new ("http://localhost:9114");
     var unionResp = helloWorldBlockingEp->testRecordValueReturn("WSO2");
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         test:assertEquals(unionResp.name, "Ballerina Language");
         test:assertEquals(unionResp.id, 0);
@@ -111,7 +110,7 @@ public function testRecordValueReturnStream() {
     HelloWorld24Client helloWorldEp = new ("http://localhost:9114");
     var unionResp = helloWorldEp->testRecordValueReturnStream("WSO2");
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     }
 }
 

--- a/grpc-ballerina/tests/27_bidirectional_streaming_client.bal
+++ b/grpc-ballerina/tests/27_bidirectional_streaming_client.bal
@@ -25,8 +25,7 @@ function testBidiStreamingFromReturn() {
     // Executing unary non-blocking call registering server message listener.
     var res = chatEp->chat();
     if (res is Error) {
-        string msg = io:sprintf(ERROR_MSG_FORMAT, res.message());
-        io:println(msg);
+        io:println(string `Error from Connector: ${res.message()}`);
     } else {
         streamingClient = res;
     }

--- a/grpc-ballerina/tests/31_return_record_unary_client.bal
+++ b/grpc-ballerina/tests/31_return_record_unary_client.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/io;
 import ballerina/test;
 
 @test:Config {enable:true}
@@ -23,7 +22,7 @@ public function testUnaryRecordValueReturn() {
     SampleMsg31 reqMsg = {name: "WSO2", id: 8};
     var unionResp = ep->sayHello(reqMsg);
     if (unionResp is Error) {
-        test:assertFail(msg = io:sprintf(ERROR_MSG_FORMAT, unionResp.message()));
+        test:assertFail(msg = string `Error from Connector: ${unionResp.message()}`);
     } else {
         SampleMsg31 resMsg = <SampleMsg31>unionResp.content;
         test:assertEquals(resMsg.name, "Ballerina Lang");


### PR DESCRIPTION
## Purpose
This is to remove `sprintf` usages in the grpc module and remove previous coverage report config