### PR TITLE
Make publish tasks to be depends on the copyExternalJars task

### DIFF
--- a/grpc-ballerina/build.gradle
+++ b/grpc-ballerina/build.gradle
@@ -186,13 +186,15 @@ task revertTomlFiles {
 }
 
 task copyExternalJars {
-    copy {
-        from targetNativeJar
-        into file("$artifactLibParent/libs")
-    }
-    copy {
-        from externalGoogleProtosCommonJar
-        into file("$artifactLibParent/libs")
+    doLast {
+        copy {
+            from targetNativeJar
+            into file("$artifactLibParent/libs")
+        }
+        copy {
+            from externalGoogleProtosCommonJar
+            into file("$artifactLibParent/libs")
+        }
     }
 }
 
@@ -225,5 +227,7 @@ test.dependsOn ":${packageName}-native:build"
 test.dependsOn ":${packageName}-test-utils:build"
 test.dependsOn ":${packageName}-compiler-plugin:build"
 
+publishToMavenLocal.dependsOn copyExternalJars
+publish.dependsOn copyExternalJars
 publishToMavenLocal.dependsOn build
 publish.dependsOn build


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1387

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
