### PR TITLE
Fix the repetitive usage of headers variable in server streaming

### DIFF
--- a/grpc-ballerina/tests/resources/generated-sources/tool_test_data_type_13/helloWorldWithDuplicateInputOutput_pb.bal
+++ b/grpc-ballerina/tests/resources/generated-sources/tool_test_data_type_13/helloWorldWithDuplicateInputOutput_pb.bal
@@ -101,9 +101,9 @@ public isolated client class ChatClient {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("Chat/call3", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         StringStream outputStream = new StringStream(result);
-        return {content: new stream<string, grpc:Error?>(outputStream), headers: headers};
+        return {content: new stream<string, grpc:Error?>(outputStream), headers: respHeaders};
     }
 
     isolated remote function call4(Msg|ContextMsg req) returns stream<string, grpc:Error?>|grpc:Error {
@@ -131,9 +131,9 @@ public isolated client class ChatClient {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("Chat/call4", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         StringStream outputStream = new StringStream(result);
-        return {content: new stream<string, grpc:Error?>(outputStream), headers: headers};
+        return {content: new stream<string, grpc:Error?>(outputStream), headers: respHeaders};
     }
 
     isolated remote function call7() returns (Call7StreamingClient|grpc:Error) {
@@ -248,9 +248,9 @@ public isolated client class Chat2Client {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("Chat2/call3", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         StringStream outputStream = new StringStream(result);
-        return {content: new stream<string, grpc:Error?>(outputStream), headers: headers};
+        return {content: new stream<string, grpc:Error?>(outputStream), headers: respHeaders};
     }
 
     isolated remote function call4(Msg|ContextMsg req) returns stream<string, grpc:Error?>|grpc:Error {
@@ -278,9 +278,9 @@ public isolated client class Chat2Client {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("Chat2/call4", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         StringStream outputStream = new StringStream(result);
-        return {content: new stream<string, grpc:Error?>(outputStream), headers: headers};
+        return {content: new stream<string, grpc:Error?>(outputStream), headers: respHeaders};
     }
 
     isolated remote function call7() returns (Call7StreamingClient|grpc:Error) {

--- a/grpc-ballerina/tests/resources/generated-sources/tool_test_server_1/helloWorldString_pb.bal
+++ b/grpc-ballerina/tests/resources/generated-sources/tool_test_server_1/helloWorldString_pb.bal
@@ -35,11 +35,11 @@ public isolated client class helloWorldClient {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("helloWorld/hello", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         StringStream outputStream = new StringStream(result);
         return {
             content: new stream<string, grpc:Error?>(outputStream),
-            headers: headers
+            headers: respHeaders
         };
     }
 }

--- a/grpc-ballerina/tests/resources/generated-sources/tool_test_server_2/helloWorldInt_pb.bal
+++ b/grpc-ballerina/tests/resources/generated-sources/tool_test_server_2/helloWorldInt_pb.bal
@@ -35,11 +35,11 @@ public isolated client class helloWorldClient {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("helloWorld/hello", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         IntStream outputStream = new IntStream(result);
         return {
             content: new stream<int, grpc:Error?>(outputStream),
-            headers: headers
+            headers: respHeaders
         };
     }
 }

--- a/grpc-ballerina/tests/resources/generated-sources/tool_test_server_3/helloWorldFloat_pb.bal
+++ b/grpc-ballerina/tests/resources/generated-sources/tool_test_server_3/helloWorldFloat_pb.bal
@@ -35,11 +35,11 @@ public isolated client class helloWorldClient {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("helloWorld/hello", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         FloatStream outputStream = new FloatStream(result);
         return {
             content: new stream<float, grpc:Error?>(outputStream),
-            headers: headers
+            headers: respHeaders
         };
     }
 }

--- a/grpc-ballerina/tests/resources/generated-sources/tool_test_server_4/helloWorldBoolean_pb.bal
+++ b/grpc-ballerina/tests/resources/generated-sources/tool_test_server_4/helloWorldBoolean_pb.bal
@@ -35,11 +35,11 @@ public isolated client class helloWorldClient {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("helloWorld/hello", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         BooleanStream outputStream = new BooleanStream(result);
         return {
             content: new stream<boolean, grpc:Error?>(outputStream),
-            headers: headers
+            headers: respHeaders
         };
     }
 }

--- a/grpc-ballerina/tests/resources/generated-sources/tool_test_server_5/helloWorldBytes_pb.bal
+++ b/grpc-ballerina/tests/resources/generated-sources/tool_test_server_5/helloWorldBytes_pb.bal
@@ -35,11 +35,11 @@ public isolated client class helloWorldClient {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("helloWorld/hello", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         BytesStream outputStream = new BytesStream(result);
         return {
             content: new stream<byte[], grpc:Error?>(outputStream),
-            headers: headers
+            headers: respHeaders
         };
     }
 }

--- a/grpc-ballerina/tests/resources/generated-sources/tool_test_server_6/helloWorldMessage_pb.bal
+++ b/grpc-ballerina/tests/resources/generated-sources/tool_test_server_6/helloWorldMessage_pb.bal
@@ -35,11 +35,11 @@ public isolated client class helloWorldClient {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("helloWorld/hello", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         HelloResponseStream outputStream = new HelloResponseStream(result);
         return {
             content: new stream<HelloResponse, grpc:Error?>(outputStream),
-            headers: headers
+            headers: respHeaders
         };
     }
 
@@ -68,11 +68,11 @@ public isolated client class helloWorldClient {
             message = req;
         }
         var payload = check self.grpcClient->executeServerStreaming("helloWorld/bye", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         ByeResponseStream outputStream = new ByeResponseStream(result);
         return {
             content: new stream<ByeResponse, grpc:Error?>(outputStream),
-            headers: headers
+            headers: respHeaders
         };
     }
 }

--- a/grpc-ballerina/tests/resources/generated-sources/tool_test_server_7/helloWorldInputEmptyOutputMessage_pb.bal
+++ b/grpc-ballerina/tests/resources/generated-sources/tool_test_server_7/helloWorldInputEmptyOutputMessage_pb.bal
@@ -23,11 +23,11 @@ public isolated client class helloWorldClient {
         Empty message = {};
         map<string|string[]> headers = {};
         var payload = check self.grpcClient->executeServerStreaming("grpcservices.helloWorld/testNoInputOutputStruct", message, headers);
-        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, headers] = payload;
+        [stream<anydata, grpc:Error?>, map<string|string[]>] [result, respHeaders] = payload;
         HelloResponseStream outputStream = new HelloResponseStream(result);
         return {
             content: new stream<HelloResponse, grpc:Error?>(outputStream),
-            headers: headers
+            headers: respHeaders
         };
     }
 }

--- a/grpc-native/src/main/java/org/ballerinalang/net/grpc/builder/syntaxtree/utils/ServerUtils.java
+++ b/grpc-native/src/main/java/org/ballerinalang/net/grpc/builder/syntaxtree/utils/ServerUtils.java
@@ -141,7 +141,7 @@ public class ServerUtils {
                         SYNTAX_TREE_GRPC_ERROR
                 )
         );
-        addServerBody(function, method, inputCap, outputCap, "headers");
+        addServerBody(function, method, inputCap, outputCap, "respHeaders");
         Map returnMap = new Map();
         returnMap.addField(
                 "content",
@@ -153,7 +153,7 @@ public class ServerUtils {
                         new String[]{"outputStream"}
                 )
         );
-        returnMap.addSimpleNameReferenceField("headers", "headers");
+        returnMap.addSimpleNameReferenceField("headers", "respHeaders");
         function.addReturnStatement(returnMap.getMappingConstructorExpressionNode());
         function.addQualifiers(new String[]{"isolated", "remote"});
         return function;


### PR DESCRIPTION
## Purpose
Previously, the variable name `headers` has been used to represent both incoming and outgoing headers. Here, we rename the outgoing headers variable name as `respHeaders`. It adheres to the unary case as well.

Related to - https://github.com/ballerina-platform/module-ballerina-grpc/pull/304

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
