### PR TITLE
Fix invalid string value for cert validation type in GrpcConstants.java

### DIFF
--- a/grpc-native/src/main/java/org/ballerinalang/net/grpc/GrpcConstants.java
+++ b/grpc-native/src/main/java/org/ballerinalang/net/grpc/GrpcConstants.java
@@ -261,7 +261,7 @@ public class GrpcConstants {
     public static final BString SECURESOCKET_CONFIG_PROTOCOL_NAME = StringUtils.fromString("name");
     public static final BString SECURESOCKET_CONFIG_PROTOCOL_VERSIONS = StringUtils.fromString("versions");
     public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION = StringUtils.fromString("certValidation");
-    public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE = StringUtils.fromString("cacheSize");
+    public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION_TYPE = StringUtils.fromString("type");
     public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_SIZE = StringUtils.fromString("cacheSize");
     public static final BString SECURESOCKET_CONFIG_CERT_VALIDATION_CACHE_VALIDITY_PERIOD =
             StringUtils.fromString("cacheValidityPeriod");


### PR DESCRIPTION
## Purpose
$title
## Examples
N/A

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1631