### PR TITLE
Fix the gRPC backward incompatibility issue when adding a new field

### DIFF
--- a/ballerina/tests/54_backward_compatible_client.bal
+++ b/ballerina/tests/54_backward_compatible_client.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/test;
+
+@test:Config {}
+isolated function testBackwardCompatibility() returns error? {
+    ProductCatalogClient ep = check new ("http://localhost:9154");
+    Product product = check ep->getProduct("N001");
+    test:assertEquals(product, {name: "Noodles", id: 1009});
+
+    string customerName = check ep->sendCustomer({name: "John", id: 100, additional: ""});
+    test:assertEquals(customerName, "John");
+}
+

--- a/ballerina/tests/54_backward_compatible_client_proto.proto
+++ b/ballerina/tests/54_backward_compatible_client_proto.proto
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+syntax = "proto3";
+import "google/protobuf/wrappers.proto";
+
+package grpcservices;
+
+service ProductCatalog {
+    rpc getProduct (google.protobuf.StringValue) returns (Product);
+    rpc sendCustomer(ChangedCustomer) returns (google.protobuf.StringValue);
+}
+
+message Product {
+    string name = 1;
+    int32 id = 2;
+};
+
+message ChangedCustomer {
+    string name = 1;
+    int32 id = 2;
+    string additional = 3;
+};

--- a/ballerina/tests/54_backward_compatible_pb.bal
+++ b/ballerina/tests/54_backward_compatible_pb.bal
@@ -1,0 +1,206 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public isolated client class ProductCatalogClient {
+    *AbstractClientEndpoint;
+
+    private final Client grpcClient;
+
+    public isolated function init(string url, *ClientConfiguration config) returns Error? {
+        self.grpcClient = check new (url, config);
+        check self.grpcClient.initStub(self, ROOT_DESCRIPTOR_54_CLIENT, getDescriptorMap54Client());
+    }
+
+    isolated remote function getProduct(string|ContextString req) returns (Product|Error) {
+        map<string|string[]> headers = {};
+        string message;
+        if (req is ContextString) {
+            message = req.content;
+            headers = req.headers;
+        } else {
+            message = req;
+        }
+        var payload = check self.grpcClient->executeSimpleRPC("grpcservices.ProductCatalog/getProduct", message, headers);
+        [anydata, map<string|string[]>] [result, _] = payload;
+        return <Product>result;
+    }
+
+    isolated remote function getProductContext(string|ContextString req) returns (ContextProduct|Error) {
+        map<string|string[]> headers = {};
+        string message;
+        if (req is ContextString) {
+            message = req.content;
+            headers = req.headers;
+        } else {
+            message = req;
+        }
+        var payload = check self.grpcClient->executeSimpleRPC("grpcservices.ProductCatalog/getProduct", message, headers);
+        [anydata, map<string|string[]>] [result, respHeaders] = payload;
+        return {content: <Product>result, headers: respHeaders};
+    }
+
+    isolated remote function sendCustomer(ChangedCustomer|ContextChangedCustomer req) returns (string|Error) {
+        map<string|string[]> headers = {};
+        ChangedCustomer message;
+        if (req is ContextChangedCustomer) {
+            message = req.content;
+            headers = req.headers;
+        } else {
+            message = req;
+        }
+        var payload = check self.grpcClient->executeSimpleRPC("grpcservices.ProductCatalog/sendCustomer", message, headers);
+        [anydata, map<string|string[]>] [result, _] = payload;
+        return result.toString();
+    }
+
+    isolated remote function sendCustomerContext(ChangedCustomer|ContextChangedCustomer req) returns (ContextString|Error) {
+        map<string|string[]> headers = {};
+        ChangedCustomer message;
+        if (req is ContextChangedCustomer) {
+            message = req.content;
+            headers = req.headers;
+        } else {
+            message = req;
+        }
+        var payload = check self.grpcClient->executeSimpleRPC("grpcservices.ProductCatalog/sendCustomer", message, headers);
+        [anydata, map<string|string[]>] [result, respHeaders] = payload;
+        return {content: result.toString(), headers: respHeaders};
+    }
+}
+
+public client class ProductCatalogStringCaller {
+    private Caller caller;
+
+    public isolated function init(Caller caller) {
+        self.caller = caller;
+    }
+
+    public isolated function getId() returns int {
+        return self.caller.getId();
+    }
+
+    isolated remote function sendString(string response) returns Error? {
+        return self.caller->send(response);
+    }
+
+    isolated remote function sendContextString(ContextString response) returns Error? {
+        return self.caller->send(response);
+    }
+
+    isolated remote function sendError(Error response) returns Error? {
+        return self.caller->sendError(response);
+    }
+
+    isolated remote function complete() returns Error? {
+        return self.caller->complete();
+    }
+
+    public isolated function isCancelled() returns boolean {
+        return self.caller.isCancelled();
+    }
+}
+
+public client class ProductCatalogChangedProductCaller {
+    private Caller caller;
+
+    public isolated function init(Caller caller) {
+        self.caller = caller;
+    }
+
+    public isolated function getId() returns int {
+        return self.caller.getId();
+    }
+
+    isolated remote function sendChangedProduct(ChangedProduct response) returns Error? {
+        return self.caller->send(response);
+    }
+
+    isolated remote function sendContextChangedProduct(ContextChangedProduct response) returns Error? {
+        return self.caller->send(response);
+    }
+
+    isolated remote function sendError(Error response) returns Error? {
+        return self.caller->sendError(response);
+    }
+
+    isolated remote function complete() returns Error? {
+        return self.caller->complete();
+    }
+
+    public isolated function isCancelled() returns boolean {
+        return self.caller.isCancelled();
+    }
+}
+
+//public type ContextString record {|
+//    string content;
+//    map<string|string[]> headers;
+//|};
+
+public type ContextCustomer record {|
+    Customer content;
+    map<string|string[]> headers;
+|};
+
+public type ContextChangedProduct record {|
+    ChangedProduct content;
+    map<string|string[]> headers;
+|};
+
+public type ContextChangedCustomer record {|
+    ChangedCustomer content;
+    map<string|string[]> headers;
+|};
+
+public type ContextProduct record {|
+    Product content;
+    map<string|string[]> headers;
+|};
+
+public type Customer record {|
+    string name = "";
+    int id = 0;
+|};
+
+public type ChangedProduct record {|
+    string name = "";
+    int id = 0;
+    string additional = "";
+|};
+
+public type ChangedCustomer record {|
+    string name = "";
+    int id = 0;
+    string additional = "";
+|};
+
+public type Product record {|
+    string name = "";
+    int id = 0;
+|};
+
+const string ROOT_DESCRIPTOR_54_SERVER = "0A2935345F6261636B776172645F636F6D70617469626C655F7365727665725F70726F746F2E70726F746F120C6772706373657276696365731A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F22540A0E4368616E67656450726F6475637412120A046E616D6518012001280952046E616D65120E0A02696418022001280552026964121E0A0A6164646974696F6E616C180320012809520A6164646974696F6E616C222E0A08437573746F6D657212120A046E616D6518012001280952046E616D65120E0A0269641802200128055202696432A0010A0E50726F64756374436174616C6F6712480A0A67657450726F64756374121C2E676F6F676C652E70726F746F6275662E537472696E6756616C75651A1C2E6772706373657276696365732E4368616E67656450726F6475637412440A0C73656E64437573746F6D657212162E6772706373657276696365732E437573746F6D65721A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C7565620670726F746F33";
+
+isolated function getDescriptorMap54Server() returns map<string> {
+    return {"54_backward_compatible_server_proto.proto": "0A2935345F6261636B776172645F636F6D70617469626C655F7365727665725F70726F746F2E70726F746F120C6772706373657276696365731A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F22540A0E4368616E67656450726F6475637412120A046E616D6518012001280952046E616D65120E0A02696418022001280552026964121E0A0A6164646974696F6E616C180320012809520A6164646974696F6E616C222E0A08437573746F6D657212120A046E616D6518012001280952046E616D65120E0A0269641802200128055202696432A0010A0E50726F64756374436174616C6F6712480A0A67657450726F64756374121C2E676F6F676C652E70726F746F6275662E537472696E6756616C75651A1C2E6772706373657276696365732E4368616E67656450726F6475637412440A0C73656E64437573746F6D657212162E6772706373657276696365732E437573746F6D65721A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C7565620670726F746F33", "google/protobuf/wrappers.proto": "0A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F120F676F6F676C652E70726F746F62756622230A0B446F75626C6556616C756512140A0576616C7565180120012801520576616C756522220A0A466C6F617456616C756512140A0576616C7565180120012802520576616C756522220A0A496E74363456616C756512140A0576616C7565180120012803520576616C756522230A0B55496E74363456616C756512140A0576616C7565180120012804520576616C756522220A0A496E74333256616C756512140A0576616C7565180120012805520576616C756522230A0B55496E74333256616C756512140A0576616C756518012001280D520576616C756522210A09426F6F6C56616C756512140A0576616C7565180120012808520576616C756522230A0B537472696E6756616C756512140A0576616C7565180120012809520576616C756522220A0A427974657356616C756512140A0576616C756518012001280C520576616C756542570A13636F6D2E676F6F676C652E70726F746F627566420D577261707065727350726F746F50015A057479706573F80101A20203475042AA021E476F6F676C652E50726F746F6275662E57656C6C4B6E6F776E5479706573620670726F746F33"};
+}
+
+const string ROOT_DESCRIPTOR_54_CLIENT = "0A2935345F6261636B776172645F636F6D70617469626C655F636C69656E745F70726F746F2E70726F746F120C6772706373657276696365731A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F222D0A0750726F6475637412120A046E616D6518012001280952046E616D65120E0A0269641802200128055202696422550A0F4368616E676564437573746F6D657212120A046E616D6518012001280952046E616D65120E0A02696418022001280552026964121E0A0A6164646974696F6E616C180320012809520A6164646974696F6E616C32A0010A0E50726F64756374436174616C6F6712410A0A67657450726F64756374121C2E676F6F676C652E70726F746F6275662E537472696E6756616C75651A152E6772706373657276696365732E50726F64756374124B0A0C73656E64437573746F6D6572121D2E6772706373657276696365732E4368616E676564437573746F6D65721A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C7565620670726F746F33";
+
+isolated function getDescriptorMap54Client() returns map<string> {
+    return {"54_backward_compatible_client_proto.proto": "0A2935345F6261636B776172645F636F6D70617469626C655F636C69656E745F70726F746F2E70726F746F120C6772706373657276696365731A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F222D0A0750726F6475637412120A046E616D6518012001280952046E616D65120E0A0269641802200128055202696422550A0F4368616E676564437573746F6D657212120A046E616D6518012001280952046E616D65120E0A02696418022001280552026964121E0A0A6164646974696F6E616C180320012809520A6164646974696F6E616C32A0010A0E50726F64756374436174616C6F6712410A0A67657450726F64756374121C2E676F6F676C652E70726F746F6275662E537472696E6756616C75651A152E6772706373657276696365732E50726F64756374124B0A0C73656E64437573746F6D6572121D2E6772706373657276696365732E4368616E676564437573746F6D65721A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C7565620670726F746F33", "google/protobuf/wrappers.proto": "0A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F120F676F6F676C652E70726F746F62756622230A0B446F75626C6556616C756512140A0576616C7565180120012801520576616C756522220A0A466C6F617456616C756512140A0576616C7565180120012802520576616C756522220A0A496E74363456616C756512140A0576616C7565180120012803520576616C756522230A0B55496E74363456616C756512140A0576616C7565180120012804520576616C756522220A0A496E74333256616C756512140A0576616C7565180120012805520576616C756522230A0B55496E74333256616C756512140A0576616C756518012001280D520576616C756522210A09426F6F6C56616C756512140A0576616C7565180120012808520576616C756522230A0B537472696E6756616C756512140A0576616C7565180120012809520576616C756522220A0A427974657356616C756512140A0576616C756518012001280C520576616C756542570A13636F6D2E676F6F676C652E70726F746F627566420D577261707065727350726F746F50015A057479706573F80101A20203475042AA021E476F6F676C652E50726F746F6275662E57656C6C4B6E6F776E5479706573620670726F746F33"};
+}
+

--- a/ballerina/tests/54_backward_compatible_server.bal
+++ b/ballerina/tests/54_backward_compatible_server.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+listener Listener ep54 = new (9154);
+
+@ServiceDescriptor {descriptor: ROOT_DESCRIPTOR_54_SERVER, descMap: getDescriptorMap54Server()}
+service "ProductCatalog" on ep54 {
+
+    isolated remote function getProduct(string value) returns ChangedProduct|error {
+        return {name: "Noodles", id: 1009, additional: "add"};
+    }
+    
+    isolated remote function sendCustomer(Customer value) returns string|error {
+        return value.name;
+    }
+}
+

--- a/ballerina/tests/54_backward_compatible_server_proto.proto
+++ b/ballerina/tests/54_backward_compatible_server_proto.proto
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+syntax = "proto3";
+import "google/protobuf/wrappers.proto";
+
+package grpcservices;
+
+service ProductCatalog {
+    rpc getProduct (google.protobuf.StringValue) returns (ChangedProduct);
+    rpc sendCustomer(Customer) returns (google.protobuf.StringValue);
+}
+
+message ChangedProduct {
+    string name = 1;
+    int32 id = 2;
+    string additional = 3;
+};
+
+message Customer {
+    string name = 1;
+    int32 id = 2;
+};

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [Add Timestamp record type generation and runtime support](https://github.com/ballerina-platform/ballerina-standard-library/issues/393)
+- [Add gRPC Duration support](https://github.com/ballerina-platform/ballerina-standard-library/issues/1610)
+- [Support a directory with protos as input in gRPC tool](https://github.com/ballerina-platform/ballerina-standard-library/issues/1626)
+
+### Changed
+- [Change the group ID and rename the sub modules](https://github.com/ballerina-platform/ballerina-standard-library/issues/1623)
+
+### Fixed 
+- [Fix invalid string value for cert validation type in GrpcConstants.java](https://github.com/ballerina-platform/ballerina-standard-library/issues/1631)
+- [Fix invalid int value conversion in GrpcUtil.java for cert validation](https://github.com/ballerina-platform/ballerina-standard-library/issues/1632)
+- [Fix the gRPC backward incompatibility issue when adding a new field](https://github.com/ballerina-platform/ballerina-standard-library/issues/1572)
+
+## [0.8.0-beta.2] - 2021-07-06
 ### Changed
 - Rename `grpc:ListenerLdapUserStoreBasicAuthProvider` as `grpc:ListenerLdapUserStoreBasicAuthHandler`
 

--- a/native/src/main/java/io/ballerina/stdlib/grpc/Message.java
+++ b/native/src/main/java/io/ballerina/stdlib/grpc/Message.java
@@ -19,6 +19,7 @@ import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.WireFormat;
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.TypeTags;
@@ -206,7 +207,13 @@ public class Message {
         }
         boolean done = false;
         while (!done) {
-            int tag = input.readTag();
+            int tag;
+            try {
+                tag = input.readTag();
+            } catch (InvalidProtocolBufferException e) {
+                tag = input.getLastTag();
+            }
+
             if (tag == 0) {
                 done = true;
             } else if (fieldDescriptors.containsKey(tag)) {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1572

`CodeInputStream.readTag` function returns and `InvalidProtocolBufferException` when it could not find the field in the wire. Before throwing that exception, it updates the last tag with the currently reading tag (unknown tag). Here, we handle the exception and assign the last tag value to the currently executing tag variable. Although we set the variable, it won't process because the unknown tag is not in the protobuf file. But anyway, it returns the expected message to the user without throwing an exception.

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
