### PR TITLE
Add ref parameter to losd test invoke workflow

### DIFF
--- a/.github/workflows/invoke-load-tests.yml
+++ b/.github/workflows/invoke-load-tests.yml
@@ -31,5 +31,6 @@ jobs:
         with:
           workflow: Stdlib Workflow
           repo: ballerina-platform/ballerina-performance-cloud
+          ref: refs/heads/main
           token: ${{ secrets.BALLERINA_BOT_TOKEN }}
           inputs: '{ "repo-name": "module-ballerina-grpc", "tests": "${{ github.event.inputs.tests }}", "zipURL": ${{ steps.setRuntimeUrl.outputs.runtimeUrl}}, "clusterName": "${{ github.event.inputs.clusterName }}" }'


### PR DESCRIPTION
## Purpose
Adding ref parameter since the performance cloud repo have main as the head branch instead of master
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
