### PR TITLE
Stop test docker container when build task completes

### DIFF
--- a/ballerina-tests/build.gradle
+++ b/ballerina-tests/build.gradle
@@ -290,6 +290,7 @@ task stopGoServer() {
     }
 }
 
+build.finalizedBy stopGoServer
 build.dependsOn ":${packageName}-test-utils:build"
 ballerinaTest.finalizedBy stopLdapServer
 ballerinaTest.dependsOn startLdapServer

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -25,7 +25,7 @@ path = "./lib/antlr4-runtime-4.5.1.wso2v1.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
-path = "./lib/http-native-2.0.1-20211113-001600-91c1c20.jar"
+path = "./lib/http-native-2.0.1-20211116-130700-000dce2.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.68.Final.jar"


### PR DESCRIPTION
## Purpose
$subject was done to stop the `go_grpc_simple_server` docker container when the `build` task completes. Otherwise, the container will be keep running forever.

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
