### PR TITLE
Enable the gRPC CLI JAR packing

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -204,6 +204,8 @@ publishing {
     }
 }
 
+build.outputs.dir artifactLibParent // To pack Ballerina gRPC CLI
+
 updateTomlFiles.dependsOn copyStdlibs
 
 build.dependsOn "generatePomFileForMavenPublication"


### PR DESCRIPTION
## Purpose
The error happens due to the removal of the `artifactLibParent ` output directory in https://github.com/ballerina-platform/plugin-gradle/pull/68/files

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
