### PR TITLE
Improve summary PR creation logic

### DIFF
--- a/.github/workflows/create-summary-pr.yml
+++ b/.github/workflows/create-summary-pr.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create Summary Update PR
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v2
       - name: Check for existing PRs
         id: checkPRs

--- a/.github/workflows/create-summary-pr.yml
+++ b/.github/workflows/create-summary-pr.yml
@@ -10,8 +10,16 @@ jobs:
     name: Create Summary Update PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Check for existing PRs
+        id: checkPRs
+        shell: bash
+        run: printf "::set-output name=prNotExists::%s" $(gh pr list --json headRefName --jq 'isempty(.[]| .headRefName | match("nightly-"))')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GIT_PAT }}
       - name: Create pull request for new summary
+        if: ${{ steps.checkPRs.outputs.prNotExists == 'true' }}
         run: gh pr create --title "[Automated] Update summary csv files" --body "Update summary csv files"
         env:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}


### PR DESCRIPTION
## Purpose
Previously for each load tests, a new branch was created and the `Create Summary Update PR` created separate PRs for each branch. This is now fixed to create only one branch for all load test results in the performance framework. So this PR improves the logic to only create a PR onetime for all the commits.

Related to https://github.com/ballerina-platform/ballerina-performance-cloud/issues/2679

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
