### PR TITLE
Add client stream consuming to fix intermittent failure

### DIFF
--- a/ballerina-tests/tests/16_unavailable_service_client.bal
+++ b/ballerina-tests/tests/16_unavailable_service_client.bal
@@ -17,7 +17,7 @@
 import ballerina/grpc;
 import ballerina/test;
 
-@test:Config {enable: false}
+@test:Config {enable: true}
 isolated function testInvokeUnavailableService() returns grpc:Error? {
     HelloWorld16Client helloWorld16BlockingEp = check new ("http://localhost:9106");
     string name = "WSO2";

--- a/ballerina-tests/tests/43_nested_record_with_streams_client.bal
+++ b/ballerina-tests/tests/43_nested_record_with_streams_client.bal
@@ -45,7 +45,7 @@ function testNestedMessagesWithServerStreaming() returns error? {
     test:assertEquals(i, 5);
 }
 
-@test:Config {enable: false}
+@test:Config {enable: true}
 function testNestedMessagesWithClientStreaming() returns error? {
     NestedMsgServiceClient ep = check new ("http://localhost:9143");
     NestedMsg[] messages = [
@@ -65,7 +65,7 @@ function testNestedMessagesWithClientStreaming() returns error? {
     test:assertEquals(<string>response, "Ack 43");
 }
 
-@test:Config {enable: false}
+@test:Config {enable: true}
 function testNestedMessagesWithBidirectionalStreaming() returns error? {
     NestedMsgServiceClient ep = check new ("http://localhost:9143");
     NestedMsg[] sendingMessages = [

--- a/ballerina-tests/tests/43_nested_record_with_streams_service.bal
+++ b/ballerina-tests/tests/43_nested_record_with_streams_service.bal
@@ -15,6 +15,7 @@
 // under the License.
 
 import ballerina/grpc;
+import ballerina/log;
 
 listener grpc:Listener ep43 = new (9143);
 
@@ -37,6 +38,9 @@ service "NestedMsgService" on ep43 {
     }
 
     isolated remote function nestedMsgClientStreaming(stream<NestedMsg, grpc:Error?> clientStream) returns error|string {
+        check clientStream.forEach(isolated function(NestedMsg value) {
+            log:printInfo(value.name);
+        });
         return "Ack 43";
     }
 
@@ -48,6 +52,9 @@ service "NestedMsgService" on ep43 {
             {name: "Name 04", msg: {name1: "Level 01", msg1: {name2: "Level 02", msg2: {name3: "Level 03", id: 4}}}},
             {name: "Name 05", msg: {name1: "Level 01", msg1: {name2: "Level 02", msg2: {name3: "Level 03", id: 5}}}}
         ];
+        check clientStream.forEach(isolated function(NestedMsg value) {
+            log:printInfo(value.name);
+        });
         return messages.toStream();
     }
 }

--- a/ballerina-tests/tests/61_any_type_service.bal
+++ b/ballerina-tests/tests/61_any_type_service.bal
@@ -17,6 +17,7 @@
 import ballerina/time;
 import ballerina/grpc;
 import ballerina/protobuf.types.'any;
+import ballerina/log;
 
 listener grpc:Listener ep61 = new (9161);
 
@@ -54,6 +55,9 @@ service "AnyTypeServer" on ep61 {
     }
     remote function clientStreamingCall(stream<'any:Any, grpc:Error?> clientStream) returns 'any:Any|error {
         Person1 p1 = {name: "John", code: 23};
+        check clientStream.forEach(isolated function('any:Any value) {
+            log:printInfo(value.toString());
+        });
         return 'any:pack(p1);
     }
     remote function serverStreamingCall('any:Any value) returns stream<'any:Any, error?>|error {

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -18,7 +18,7 @@ path = "../test-utils/build/libs/grpc-test-utils-1.2.0-SNAPSHOT.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
-path = "./lib/ballerina-cli-2201.0.0-20211220-171700-44f9bf90.jar"
+path = "./lib/ballerina-cli-2201.0.0-20220105-065600-5c8987c1.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
@@ -26,7 +26,7 @@ path = "./lib/antlr4-runtime-4.5.1.wso2v1.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
-path = "./lib/http-native-2.2.0-20211220-231000-bd0a791.jar"
+path = "./lib/http-native-2.2.0-20220105-153000-6257cc8.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.71.Final.jar"
@@ -77,7 +77,7 @@ path = "./lib/protobuf-java-3.9.1.jar"
 path = "./lib/proto-google-common-protos-1.17.0.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/formatter-core-2201.0.0-20211220-171700-44f9bf90.jar"
+path = "./lib/formatter-core-2201.0.0-20220105-065600-5c8987c1.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/ballerina-parser-2201.0.0-20211220-171700-44f9bf90.jar"
+path = "./lib/ballerina-parser-2201.0.0-20220105-065600-5c8987c1.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -46,24 +46,11 @@ modules = [
 
 [[package]]
 org = "ballerina"
-name = "file"
-version = "1.2.0"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "os"},
-	{org = "ballerina", name = "regex"},
-	{org = "ballerina", name = "time"}
-]
-
-[[package]]
-org = "ballerina"
 name = "grpc"
 version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "crypto"},
-	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "jwt"},
 	{org = "ballerina", name = "lang.runtime"},
@@ -81,36 +68,6 @@ modules = [
 	{org = "ballerina", packageName = "grpc", moduleName = "grpc.types.struct"},
 	{org = "ballerina", packageName = "grpc", moduleName = "grpc.types.timestamp"},
 	{org = "ballerina", packageName = "grpc", moduleName = "grpc.types.wrappers"}
-]
-
-[[package]]
-org = "ballerina"
-name = "http"
-version = "2.2.0"
-dependencies = [
-	{org = "ballerina", name = "auth"},
-	{org = "ballerina", name = "cache"},
-	{org = "ballerina", name = "crypto"},
-	{org = "ballerina", name = "file"},
-	{org = "ballerina", name = "io"},
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "jwt"},
-	{org = "ballerina", name = "lang.array"},
-	{org = "ballerina", name = "lang.decimal"},
-	{org = "ballerina", name = "lang.int"},
-	{org = "ballerina", name = "lang.runtime"},
-	{org = "ballerina", name = "lang.string"},
-	{org = "ballerina", name = "lang.value"},
-	{org = "ballerina", name = "log"},
-	{org = "ballerina", name = "mime"},
-	{org = "ballerina", name = "oauth2"},
-	{org = "ballerina", name = "observe"},
-	{org = "ballerina", name = "regex"},
-	{org = "ballerina", name = "time"},
-	{org = "ballerina", name = "url"}
-]
-modules = [
-	{org = "ballerina", packageName = "http", moduleName = "http"}
 ]
 
 [[package]]
@@ -164,14 +121,6 @@ version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.__internal"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.decimal"
-version = "0.0.0"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
 ]
 
 [[package]]
@@ -230,16 +179,6 @@ modules = [
 
 [[package]]
 org = "ballerina"
-name = "mime"
-version = "2.2.0"
-dependencies = [
-	{org = "ballerina", name = "io"},
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.int"}
-]
-
-[[package]]
-org = "ballerina"
 name = "oauth2"
 version = "2.2.0"
 dependencies = [
@@ -257,14 +196,6 @@ modules = [
 org = "ballerina"
 name = "observe"
 version = "1.0.0"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-
-[[package]]
-org = "ballerina"
-name = "os"
-version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -328,14 +259,6 @@ dependencies = [
 ]
 modules = [
 	{org = "ballerina", packageName = "time", moduleName = "time"}
-]
-
-[[package]]
-org = "ballerina"
-name = "url"
-version = "2.2.0"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
 ]
 
 

--- a/native/src/main/java/io/ballerina/stdlib/grpc/nativeimpl/client/FunctionUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/grpc/nativeimpl/client/FunctionUtils.java
@@ -245,10 +245,13 @@ public class FunctionUtils extends AbstractExecute {
                         methodType.name() + " not supported");
             }
         } catch (Exception e) {
-            if (dataContext != null) {
-                dataContext.getFuture().complete(e);
+            try {
+                if (dataContext != null) {
+                    dataContext.getFuture().complete(e);
+                }
+            } finally {
+                return notifyErrorReply(INTERNAL, "gRPC Client Connector Error :" + e.getMessage());
             }
-            return notifyErrorReply(INTERNAL, "gRPC Client Connector Error :" + e.getMessage());
         }
         return null;
     }


### PR DESCRIPTION
## Purpose
$subject
`testNestedMessagesWithClientStreaming` and `testNestedMessagesWithBidirectionalStreaming` are now enabled with clientstream consumption
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/841