### PR TITLE
Pack protobuf-java JAR as an external library to the publishing ZIP

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -18,7 +18,7 @@ path = "../test-utils/build/libs/grpc-test-utils-1.2.0-SNAPSHOT.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
-path = "./lib/ballerina-cli-2201.0.0-20220111-143100-d7182bfb.jar"
+path = "./lib/ballerina-cli-2201.0.0-20220111-211400-cfd415aa.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
@@ -26,7 +26,7 @@ path = "./lib/antlr4-runtime-4.5.1.wso2v1.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
-path = "./lib/http-native-2.2.0-20220111-192200-5a447f9.jar"
+path = "./lib/http-native-2.2.0-20220112-010100-abf517a.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.71.Final.jar"
@@ -77,7 +77,7 @@ path = "./lib/protobuf-java-3.19.2.jar"
 path = "./lib/proto-google-common-protos-1.17.0.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/formatter-core-2201.0.0-20220111-143100-d7182bfb.jar"
+path = "./lib/formatter-core-2201.0.0-20220111-211400-cfd415aa.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/ballerina-parser-2201.0.0-20220111-143100-d7182bfb.jar"
+path = "./lib/ballerina-parser-2201.0.0-20220111-211400-cfd415aa.jar"

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -44,6 +44,7 @@ def compilerPluginTomlFile = new File("$project.projectDir/CompilerPlugin.toml")
 def artifactLibParent = file("$project.projectDir/build/lib_parent/")
 // external jar file which need to pack to distribution
 def externalGoogleProtosCommonJar = file("$project.projectDir/lib/proto-google-common-protos-${protoGoogleCommonsVersion}.jar")
+def externalProtobufJavaJar = file("$project.projectDir/lib/protobuf-java-${protobufJavaVersion}.jar")
 def targetNativeJar = file("$project.rootDir/native/build/libs/${packageName}-native-${project.version}.jar")
 
 def stripBallerinaExtensionVersion(String extVersion) {
@@ -177,6 +178,10 @@ task commitTomlFiles {
 
 task copyExternalJars {
     doLast {
+        copy {
+            from externalProtobufJavaJar
+            into file("$artifactLibParent/libs")
+        }
         copy {
             from targetNativeJar
             into file("$artifactLibParent/libs")


### PR DESCRIPTION
## Purpose

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2570

To resolve the following class not found issue.
```
[2022-01-11 21:56:49,028] SEVERE {b7a.log.crash} - com/google/protobuf/DescriptorProtos$FileDescriptorSet
java.lang.NoClassDefFoundError: com/google/protobuf/DescriptorProtos$FileDescriptorSet
	at io.ballerina.stdlib.grpc.protobuf.cmd.DescriptorsGenerator.generateRootDescriptor(DescriptorsGenerator.java:138)
	at io.ballerina.stdlib.grpc.protobuf.cmd.GrpcCmd.generateBalFile(GrpcCmd.java:236)
	at io.ballerina.stdlib.grpc.protobuf.cmd.GrpcCmd.execute(GrpcCmd.java:156)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at io.ballerina.cli.launcher.Main.main(Main.java:51)
Caused by: java.lang.ClassNotFoundException: com.google.protobuf.DescriptorProtos$FileDescriptorSet
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 5 more
```

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
