### PR TITLE
Allow any function except `resource` function in gRPC services by the compiler plugin

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -18,7 +18,7 @@ path = "../test-utils/build/libs/grpc-test-utils-1.2.0-SNAPSHOT.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
-path = "./lib/ballerina-cli-2201.0.0-20220121-113500-04d4226d.jar"
+path = "./lib/ballerina-cli-2201.0.0-20220124-155500-c100a354.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
@@ -26,7 +26,7 @@ path = "./lib/antlr4-runtime-4.5.1.wso2v1.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
-path = "./lib/http-native-2.2.0-20220124-014200-2992144.jar"
+path = "./lib/http-native-2.2.0-20220124-214300-66daf54.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.71.Final.jar"
@@ -77,7 +77,7 @@ path = "./lib/protobuf-java-3.19.2.jar"
 path = "./lib/proto-google-common-protos-1.17.0.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/formatter-core-2201.0.0-20220121-113500-04d4226d.jar"
+path = "./lib/formatter-core-2201.0.0-20220124-155500-c100a354.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/ballerina-parser-2201.0.0-20220121-113500-04d4226d.jar"
+path = "./lib/ballerina-parser-2201.0.0-20220124-155500-c100a354.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -18,7 +18,7 @@ path = "../test-utils/build/libs/grpc-test-utils-1.2.0-SNAPSHOT.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
-path = "./lib/ballerina-cli-2201.0.0-20220117-170500-78ef3a47.jar"
+path = "./lib/ballerina-cli-2201.0.0-20220121-113500-04d4226d.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
@@ -26,7 +26,7 @@ path = "./lib/antlr4-runtime-4.5.1.wso2v1.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
-path = "./lib/http-native-2.2.0-20220118-023900-0631b7f.jar"
+path = "./lib/http-native-2.2.0-20220124-014200-2992144.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/netty-common-4.1.71.Final.jar"
@@ -77,7 +77,7 @@ path = "./lib/protobuf-java-3.19.2.jar"
 path = "./lib/proto-google-common-protos-1.17.0.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/formatter-core-2201.0.0-20220117-170500-78ef3a47.jar"
+path = "./lib/formatter-core-2201.0.0-20220121-113500-04d4226d.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/ballerina-parser-2201.0.0-20220117-170500-78ef3a47.jar"
+path = "./lib/ballerina-parser-2201.0.0-20220121-113500-04d4226d.jar"

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/CompilerPluginTest.java
@@ -119,8 +119,8 @@ public class CompilerPluginTest {
 
         Package currentPackage = loadPackage("package_06");
         PackageCompilation compilation = currentPackage.getCompilation();
-        String errMsg = "ERROR [grpc_server_streaming_service.bal:(41:5,43:6)] only remote functions are " +
-                "allowed inside gRPC services";
+        String errMsg = "ERROR [grpc_server_streaming_service.bal:(41:5,43:6)] only an init function or remote " +
+         "methods are allowed inside gRPC services";
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.errors().toArray()[0];
         Assert.assertEquals(diagnosticResult.errors().size(), 1);
@@ -260,6 +260,14 @@ public class CompilerPluginTest {
         String[] actualErrors  = {diagnostic1.toString(), diagnostic2.toString()};
         String[] expectedErrors  = {errMsg1, errMsg2};
         Assert.assertEqualsNoOrder(actualErrors, expectedErrors);
+    }
+
+    @Test
+    public void testCompilerPluginWithInitFunction() {
+        Package currentPackage = loadPackage("package_16");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errors().size(), 0);
     }
 
     private Package loadPackage(String path) {

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/CompilerPluginTest.java
@@ -119,13 +119,13 @@ public class CompilerPluginTest {
 
         Package currentPackage = loadPackage("package_06");
         PackageCompilation compilation = currentPackage.getCompilation();
-        String errMsg = "ERROR [grpc_server_streaming_service.bal:(41:5,43:6)] only an init function or remote " +
-         "methods are allowed inside gRPC services";
+        String errMsg = "ERROR [grpc_server_streaming_service.bal:(41:5,43:6)] resource methods are not allowed " +
+         "inside gRPC services";
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.errors().toArray()[0];
         Assert.assertEquals(diagnosticResult.errors().size(), 1);
         Assert.assertEquals(diagnostic.diagnosticInfo().code(),
-                GrpcCompilerPluginConstants.CompilationErrors.ONLY_REMOTE_FUNCTIONS.getErrorCode());
+                GrpcCompilerPluginConstants.CompilationErrors.RESOURCES_NOT_ALLOWED.getErrorCode());
         Assert.assertTrue(diagnosticResult.errors().stream().anyMatch(
                 d -> errMsg.equals(d.toString())));
     }
@@ -263,7 +263,7 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testCompilerPluginWithInitFunction() {
+    public void testCompilerPluginWithInitAndNormalFunctions() {
         Package currentPackage = loadPackage("package_16");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();

--- a/compiler-plugin-tests/src/test/resources/test-src/package_06/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_06/Ballerina.toml
@@ -1,6 +1,6 @@
 [package]
 org = "grpc_test"
-name = "package_05"
+name = "package_06"
 version = "0.1.0"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/test-src/package_07/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_07/Ballerina.toml
@@ -1,6 +1,6 @@
 [package]
 org = "grpc_test"
-name = "package_03"
+name = "package_07"
 version = "0.1.0"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/test-src/package_08/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_08/Ballerina.toml
@@ -1,6 +1,6 @@
 [package]
 org = "grpc_test"
-name = "package_02"
+name = "package_08"
 version = "0.1.0"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/test-src/package_09/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_09/Ballerina.toml
@@ -1,6 +1,6 @@
 [package]
 org = "grpc_test"
-name = "package_02"
+name = "package_09"
 version = "0.1.0"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/test-src/package_10/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_10/Ballerina.toml
@@ -1,6 +1,6 @@
 [package]
 org = "grpc_test"
-name = "package_02"
+name = "package_10"
 version = "0.1.0"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/test-src/package_11/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_11/Ballerina.toml
@@ -1,6 +1,6 @@
 [package]
 org = "grpc_test"
-name = "package_02"
+name = "package_11"
 version = "0.1.0"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/test-src/package_12/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_12/Ballerina.toml
@@ -1,6 +1,6 @@
 [package]
 org = "grpc_test"
-name = "package_02"
+name = "package_12"
 version = "0.1.0"
 
 [build-options]

--- a/compiler-plugin-tests/src/test/resources/test-src/package_16/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_16/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "grpc_test"
+name = "package_16"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = false

--- a/compiler-plugin-tests/src/test/resources/test-src/package_16/grpc_unary_blocking_pb.bal
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_16/grpc_unary_blocking_pb.bal
@@ -1,0 +1,103 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/grpc;
+
+public isolated client class HelloWorldClient {
+
+    *grpc:AbstractClientEndpoint;
+
+    private final grpc:Client grpcClient;
+
+    public isolated function init(string url, *grpc:ClientConfiguration config) returns grpc:Error? {
+        // initialize client endpoint.
+        self.grpcClient = check new (url, config);
+        check self.grpcClient.initStub(self, ROOT_DESCRIPTOR, getDescriptorMap());
+    }
+
+    isolated remote function hello(string|ContextString req) returns (string|grpc:Error) {
+
+        map<string|string[]> headers = {};
+        string message;
+        if (req is ContextString) {
+            message = req.content;
+            headers = req.headers;
+        } else {
+            message = req;
+        }
+        var payload = check self.grpcClient->executeSimpleRPC("HelloWorld/hello", message, headers);
+        [anydata, map<string|string[]>] [result, _] = payload;
+        return result.toString();
+    }
+    isolated remote function helloContext(string|ContextString req) returns (ContextString|grpc:Error) {
+
+        map<string|string[]> headers = {};
+        string message;
+        if (req is ContextString) {
+            message = req.content;
+            headers = req.headers;
+        } else {
+            message = req;
+        }
+        var payload = check self.grpcClient->executeSimpleRPC("HelloWorld/hello", message, headers);
+        [anydata, map<string|string[]>] [result, respHeaders] = payload;
+        return {
+            content: result.toString(),
+            headers: respHeaders
+        };
+    }
+}
+
+public client class HelloWorldStringCaller {
+    private grpc:Caller caller;
+
+    public isolated function init(grpc:Caller caller) {
+        self.caller = caller;
+    }
+
+    public isolated function getId() returns int {
+        return self.caller.getId();
+    }
+
+    isolated remote function sendString(string response) returns grpc:Error? {
+        return self.caller->send(response);
+    }
+    isolated remote function sendContextString(ContextString response) returns grpc:Error? {
+        return self.caller->send(response);
+    }
+
+    isolated remote function sendError(grpc:Error response) returns grpc:Error? {
+        return self.caller->sendError(response);
+    }
+
+    isolated remote function complete() returns grpc:Error? {
+        return self.caller->complete();
+    }
+}
+
+public type ContextString record {|
+    string content;
+    map<string|string[]> headers;
+|};
+
+const string ROOT_DESCRIPTOR = "0A19677270635F756E6172795F626C6F636B696E672E70726F746F1A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F32510A0A48656C6C6F576F726C6412430A0568656C6C6F121C2E676F6F676C652E70726F746F6275662E537472696E6756616C75651A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C7565620670726F746F33";
+
+isolated function getDescriptorMap() returns map<string> {
+    return 
+    {
+        "grpc_unary_blocking.proto": "0A19677270635F756E6172795F626C6F636B696E672E70726F746F1A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F32510A0A48656C6C6F576F726C6412430A0568656C6C6F121C2E676F6F676C652E70726F746F6275662E537472696E6756616C75651A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C7565620670726F746F33",
+        "google/protobuf/wrappers.proto": "0A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F120F676F6F676C652E70726F746F62756622230A0B446F75626C6556616C756512140A0576616C7565180120012801520576616C756522220A0A466C6F617456616C756512140A0576616C7565180120012802520576616C756522220A0A496E74363456616C756512140A0576616C7565180120012803520576616C756522230A0B55496E74363456616C756512140A0576616C7565180120012804520576616C756522220A0A496E74333256616C756512140A0576616C7565180120012805520576616C756522230A0B55496E74333256616C756512140A0576616C756518012001280D520576616C756522210A09426F6F6C56616C756512140A0576616C7565180120012808520576616C756522230A0B537472696E6756616C756512140A0576616C7565180120012809520576616C756522220A0A427974657356616C756512140A0576616C756518012001280C520576616C756542570A13636F6D2E676F6F676C652E70726F746F627566420D577261707065727350726F746F50015A057479706573F80101A20203475042AA021E476F6F676C652E50726F746F6275662E57656C6C4B6E6F776E5479706573620670726F746F33"
+    };
+}

--- a/compiler-plugin-tests/src/test/resources/test-src/package_16/grpc_unary_blocking_service.bal
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_16/grpc_unary_blocking_service.bal
@@ -28,10 +28,11 @@ service "HelloWorld" on ep {
     function init() {
         log:printInfo("init");
     }
+
     remote function hello(ContextString request) returns ContextString|error {
         log:printInfo("Invoked the hello RPC call.");
         // Reads the request content.
-        string message = "Hello " + request.content;
+        string message = "Hello " + request.content + self.foo();
 
         // Reads custom headers in request message.
         string reqHeader = check grpc:getHeader(request.headers, "client_header_key");
@@ -42,5 +43,9 @@ service "HelloWorld" on ep {
             content: message,
             headers: {server_header_key: "Response Header value"}
         };
+    }
+
+    function foo() returns string {
+        return " msg";
     }
 }

--- a/compiler-plugin-tests/src/test/resources/test-src/package_16/grpc_unary_blocking_service.bal
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_16/grpc_unary_blocking_service.bal
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This is the server implementation of the unary blocking/unblocking scenario.
+import ballerina/grpc;
+import ballerina/log;
+
+listener grpc:Listener ep = new (9090);
+
+@grpc:ServiceDescriptor {
+    descriptor: ROOT_DESCRIPTOR,
+    descMap: getDescriptorMap()
+}
+service "HelloWorld" on ep {
+
+    function init() {
+        log:printInfo("init");
+    }
+    remote function hello(ContextString request) returns ContextString|error {
+        log:printInfo("Invoked the hello RPC call.");
+        // Reads the request content.
+        string message = "Hello " + request.content;
+
+        // Reads custom headers in request message.
+        string reqHeader = check grpc:getHeader(request.headers, "client_header_key");
+        log:printInfo("Server received header value: " + reqHeader);
+
+        // Sends response with custom headers.
+        return {
+            content: message,
+            headers: {server_header_key: "Response Header value"}
+        };
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcCompilerPluginConstants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcCompilerPluginConstants.java
@@ -35,7 +35,7 @@ public class GrpcCompilerPluginConstants {
      */
     public enum CompilationErrors {
         UNDEFINED_ANNOTATION("undefined annotation: ", "GRPC_101", DiagnosticSeverity.ERROR),
-        ONLY_REMOTE_FUNCTIONS("only remote functions are allowed inside gRPC services", "GRPC_102",
+        ONLY_REMOTE_FUNCTIONS("only an init function or remote methods are allowed inside gRPC services", "GRPC_102",
                 DiagnosticSeverity.ERROR),
         RETURN_WITH_CALLER("only `error?` return type is allowed with the caller", "GRPC_103",
                 DiagnosticSeverity.ERROR),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcCompilerPluginConstants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcCompilerPluginConstants.java
@@ -35,7 +35,7 @@ public class GrpcCompilerPluginConstants {
      */
     public enum CompilationErrors {
         UNDEFINED_ANNOTATION("undefined annotation: ", "GRPC_101", DiagnosticSeverity.ERROR),
-        ONLY_REMOTE_FUNCTIONS("only an init function or remote methods are allowed inside gRPC services", "GRPC_102",
+        RESOURCES_NOT_ALLOWED("resource methods are not allowed inside gRPC services", "GRPC_102",
                 DiagnosticSeverity.ERROR),
         RETURN_WITH_CALLER("only `error?` return type is allowed with the caller", "GRPC_103",
                 DiagnosticSeverity.ERROR),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcServiceValidator.java
@@ -179,7 +179,8 @@ public class GrpcServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
 
         boolean hasRemoteKeyword = functionDefinitionNode.qualifierList().stream()
                 .filter(q -> q.kind() == SyntaxKind.REMOTE_KEYWORD).toArray().length == 1;
-        if (!hasRemoteKeyword) {
+        boolean isInitFunction = "init".equals(functionDefinitionNode.functionName().toString());
+        if (!(hasRemoteKeyword || isInitFunction)) {
             reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
                     GrpcCompilerPluginConstants.CompilationErrors.ONLY_REMOTE_FUNCTIONS.getError(),
                     GrpcCompilerPluginConstants.CompilationErrors.ONLY_REMOTE_FUNCTIONS.getErrorCode());

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcServiceValidator.java
@@ -177,13 +177,12 @@ public class GrpcServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
     private void validateServiceFunctions(FunctionDefinitionNode functionDefinitionNode,
                                           SyntaxNodeAnalysisContext syntaxNodeAnalysisContext) {
 
-        boolean hasRemoteKeyword = functionDefinitionNode.qualifierList().stream()
-                .filter(q -> q.kind() == SyntaxKind.REMOTE_KEYWORD).toArray().length == 1;
-        boolean isInitFunction = "init".equals(functionDefinitionNode.functionName().toString());
-        if (!(hasRemoteKeyword || isInitFunction)) {
+        boolean hasResourceKeyword = functionDefinitionNode.qualifierList().stream()
+                .filter(q -> q.kind() == SyntaxKind.RESOURCE_KEYWORD).toArray().length == 1;
+        if (hasResourceKeyword) {
             reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
-                    GrpcCompilerPluginConstants.CompilationErrors.ONLY_REMOTE_FUNCTIONS.getError(),
-                    GrpcCompilerPluginConstants.CompilationErrors.ONLY_REMOTE_FUNCTIONS.getErrorCode());
+                    GrpcCompilerPluginConstants.CompilationErrors.RESOURCES_NOT_ALLOWED.getError(),
+                    GrpcCompilerPluginConstants.CompilationErrors.RESOURCES_NOT_ALLOWED.getErrorCode());
         }
     }
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2617

Compiler plugin error message when a gRPC service has a resource method.
```sh
resource methods are not allowed inside gRPC services
```


## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
