### PR TITLE
Constraint the `testBidiStreamingDefaultHttpsPortWithNoService` only to Linux

### DIFF
--- a/ballerina-tests/tests/03_bidirectional_streaming_client.bal
+++ b/ballerina-tests/tests/03_bidirectional_streaming_client.bal
@@ -253,25 +253,27 @@ isolated function testBidiStreamingWithNoPublicCertFile() returns grpc:Error? {
 
 @test:Config {enable:true}
 isolated function testBidiStreamingDefaultHttpsPortWithNoService() returns grpc:Error? {
-    ChatClient chatClient = check new ("https://localhost", {
-        secureSocket: {
-            key: {
-                certFile: PUBLIC_CRT_PATH,
-                keyFile: PRIVATE_KEY_PATH
-            },
-            cert: PUBLIC_CRT_PATH,
-            protocol:{
-                name: grpc:TLS,
-                versions: ["TLSv1.2", "TLSv1.1"]
-            },
-            ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]
-        }
-    });
-    ChatStreamingClient strClient = check chatClient->chat();
-    ChatMessage mes1 = {name:"Sam", message:"Hi"};
-    check strClient->sendChatMessage(mes1);
-    
-    string|grpc:Error? err = strClient->receiveString();
-    test:assertTrue(err is grpc:Error);
-    test:assertTrue((<grpc:Error>err).message().startsWith("Connection refused: "));
+    if !isWindowsEnvironment() {
+        ChatClient chatClient = check new ("https://localhost", {
+            secureSocket: {
+                key: {
+                    certFile: PUBLIC_CRT_PATH,
+                    keyFile: PRIVATE_KEY_PATH
+                },
+                cert: PUBLIC_CRT_PATH,
+                protocol:{
+                    name: grpc:TLS,
+                    versions: ["TLSv1.2", "TLSv1.1"]
+                },
+                ciphers: ["TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"]
+            }
+        });
+        ChatStreamingClient strClient = check chatClient->chat();
+        ChatMessage mes1 = {name:"Sam", message:"Hi"};
+        check strClient->sendChatMessage(mes1);
+
+        string|grpc:Error? err = strClient->receiveString();
+        test:assertTrue(err is grpc:Error);
+        test:assertTrue((<grpc:Error>err).message().startsWith("Connection refused: "));
+    }
 }


### PR DESCRIPTION
## Purpose
The Windows execution of this negative test is unpredictable.

Address https://github.com/ballerina-platform/ballerina-standard-library/issues/841#issuecomment-1033391337

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
