### PR TITLE
Constraint the compiler plugin validations only for remote functions

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/CompilerPluginTest.java
@@ -263,8 +263,16 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testCompilerPluginWithInitAndNormalFunctions() {
+    public void testCompilerPluginWithInitAndNormalFunctions1() {
         Package currentPackage = loadPackage("package_16");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errors().size(), 0);
+    }
+
+    @Test
+    public void testCompilerPluginWithInitAndNormalFunctions2() {
+        Package currentPackage = loadPackage("package_17");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         Assert.assertEquals(diagnosticResult.errors().size(), 0);

--- a/compiler-plugin-tests/src/test/resources/test-src/package_17/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_17/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "grpc_test"
+name = "package_17"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = false

--- a/compiler-plugin-tests/src/test/resources/test-src/package_17/grpc_unary_blocking_pb.bal
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_17/grpc_unary_blocking_pb.bal
@@ -1,0 +1,103 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/grpc;
+
+public isolated client class HelloWorldClient {
+
+    *grpc:AbstractClientEndpoint;
+
+    private final grpc:Client grpcClient;
+
+    public isolated function init(string url, *grpc:ClientConfiguration config) returns grpc:Error? {
+        // initialize client endpoint.
+        self.grpcClient = check new (url, config);
+        check self.grpcClient.initStub(self, ROOT_DESCRIPTOR, getDescriptorMap());
+    }
+
+    isolated remote function hello(string|ContextString req) returns (string|grpc:Error) {
+
+        map<string|string[]> headers = {};
+        string message;
+        if (req is ContextString) {
+            message = req.content;
+            headers = req.headers;
+        } else {
+            message = req;
+        }
+        var payload = check self.grpcClient->executeSimpleRPC("HelloWorld/hello", message, headers);
+        [anydata, map<string|string[]>] [result, _] = payload;
+        return result.toString();
+    }
+    isolated remote function helloContext(string|ContextString req) returns (ContextString|grpc:Error) {
+
+        map<string|string[]> headers = {};
+        string message;
+        if (req is ContextString) {
+            message = req.content;
+            headers = req.headers;
+        } else {
+            message = req;
+        }
+        var payload = check self.grpcClient->executeSimpleRPC("HelloWorld/hello", message, headers);
+        [anydata, map<string|string[]>] [result, respHeaders] = payload;
+        return {
+            content: result.toString(),
+            headers: respHeaders
+        };
+    }
+}
+
+public client class HelloWorldStringCaller {
+    private grpc:Caller caller;
+
+    public isolated function init(grpc:Caller caller) {
+        self.caller = caller;
+    }
+
+    public isolated function getId() returns int {
+        return self.caller.getId();
+    }
+
+    isolated remote function sendString(string response) returns grpc:Error? {
+        return self.caller->send(response);
+    }
+    isolated remote function sendContextString(ContextString response) returns grpc:Error? {
+        return self.caller->send(response);
+    }
+
+    isolated remote function sendError(grpc:Error response) returns grpc:Error? {
+        return self.caller->sendError(response);
+    }
+
+    isolated remote function complete() returns grpc:Error? {
+        return self.caller->complete();
+    }
+}
+
+public type ContextString record {|
+    string content;
+    map<string|string[]> headers;
+|};
+
+const string ROOT_DESCRIPTOR = "0A19677270635F756E6172795F626C6F636B696E672E70726F746F1A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F32510A0A48656C6C6F576F726C6412430A0568656C6C6F121C2E676F6F676C652E70726F746F6275662E537472696E6756616C75651A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C7565620670726F746F33";
+
+isolated function getDescriptorMap() returns map<string> {
+    return 
+    {
+        "grpc_unary_blocking.proto": "0A19677270635F756E6172795F626C6F636B696E672E70726F746F1A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F32510A0A48656C6C6F576F726C6412430A0568656C6C6F121C2E676F6F676C652E70726F746F6275662E537472696E6756616C75651A1C2E676F6F676C652E70726F746F6275662E537472696E6756616C7565620670726F746F33",
+        "google/protobuf/wrappers.proto": "0A1E676F6F676C652F70726F746F6275662F77726170706572732E70726F746F120F676F6F676C652E70726F746F62756622230A0B446F75626C6556616C756512140A0576616C7565180120012801520576616C756522220A0A466C6F617456616C756512140A0576616C7565180120012802520576616C756522220A0A496E74363456616C756512140A0576616C7565180120012803520576616C756522230A0B55496E74363456616C756512140A0576616C7565180120012804520576616C756522220A0A496E74333256616C756512140A0576616C7565180120012805520576616C756522230A0B55496E74333256616C756512140A0576616C756518012001280D520576616C756522210A09426F6F6C56616C756512140A0576616C7565180120012808520576616C756522230A0B537472696E6756616C756512140A0576616C7565180120012809520576616C756522220A0A427974657356616C756512140A0576616C756518012001280C520576616C756542570A13636F6D2E676F6F676C652E70726F746F627566420D577261707065727350726F746F50015A057479706573F80101A20203475042AA021E476F6F676C652E50726F746F6275662E57656C6C4B6E6F776E5479706573620670726F746F33"
+    };
+}

--- a/compiler-plugin-tests/src/test/resources/test-src/package_17/grpc_unary_blocking_service.bal
+++ b/compiler-plugin-tests/src/test/resources/test-src/package_17/grpc_unary_blocking_service.bal
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This is the server implementation of the unary blocking/unblocking scenario.
+import ballerina/grpc;
+import ballerina/log;
+
+listener grpc:Listener ep = new (9090);
+
+@grpc:ServiceDescriptor {
+    descriptor: ROOT_DESCRIPTOR,
+    descMap: getDescriptorMap()
+}
+service "HelloWorld" on ep {
+
+    function init() {
+        log:printInfo("init");
+    }
+
+    remote function hello(ContextString request) returns ContextString|error {
+        log:printInfo("Invoked the hello RPC call.");
+        // Reads the request content.
+        string message = "Hello " + request.content + self.foo("");
+
+        // Reads custom headers in request message.
+        string reqHeader = check grpc:getHeader(request.headers, "client_header_key");
+        log:printInfo("Server received header value: " + reqHeader);
+
+        // Sends response with custom headers.
+        return {
+            content: message,
+            headers: {server_header_key: "Response Header value"}
+        };
+    }
+
+    function foo(string msg) returns string {
+        return " msg";
+    }
+
+    function bar(ContextString request, string s) {
+        
+    }
+
+    function withCaller(HelloWorldStringCaller caller, ContextString request, string s, int n) returns int {
+        return 1;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcServiceValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcServiceValidator.java
@@ -90,8 +90,11 @@ public class GrpcServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
                     // Check functions are remote or not
                     validateServiceFunctions(functionDefinitionNode, syntaxNodeAnalysisContext);
                     // Check params and return types
-                    validateFunctionSignature(functionDefinitionNode, syntaxNodeAnalysisContext, serviceName);
-
+                    boolean isRemoteFunction = functionDefinitionNode.qualifierList().stream()
+                            .filter(q -> q.kind() == SyntaxKind.REMOTE_KEYWORD).toArray().length == 1;
+                    if (isRemoteFunction) {
+                        validateFunctionSignature(functionDefinitionNode, syntaxNodeAnalysisContext, serviceName);
+                    }
                 });
             }
 
@@ -189,67 +192,62 @@ public class GrpcServiceValidator implements AnalysisTask<SyntaxNodeAnalysisCont
     private void validateFunctionSignature(FunctionDefinitionNode functionDefinitionNode,
                                            SyntaxNodeAnalysisContext syntaxNodeAnalysisContext, String serviceName) {
 
-        boolean isRemoteFunction = functionDefinitionNode.qualifierList().stream()
-                .filter(q -> q.kind() == SyntaxKind.REMOTE_KEYWORD).toArray().length == 1;
+        FunctionSignatureNode functionSignatureNode = functionDefinitionNode.functionSignature();
+        SeparatedNodeList<ParameterNode> parameterNodes = functionSignatureNode.parameters();
+        if (parameterNodes.size() == 2) {
+            String firstParameter = typeNameFromParameterNode(functionSignatureNode.parameters().get(0));
 
-        if (isRemoteFunction) {
-            FunctionSignatureNode functionSignatureNode = functionDefinitionNode.functionSignature();
-            SeparatedNodeList<ParameterNode> parameterNodes = functionSignatureNode.parameters();
-            if (parameterNodes.size() == 2) {
-                String firstParameter = typeNameFromParameterNode(functionSignatureNode.parameters().get(0));
-
-                if (!firstParameter.toLowerCase(Locale.ENGLISH).contains(GRPC_GENERIC_CALLER)) {
-                    reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
-                            GrpcCompilerPluginConstants.CompilationErrors.TWO_PARAMS_WITHOUT_CALLER.getError(),
-                            GrpcCompilerPluginConstants.CompilationErrors.TWO_PARAMS_WITHOUT_CALLER.getErrorCode());
-                } else if (!(firstParameter.startsWith(serviceName) && firstParameter.endsWith(GRPC_EXACT_CALLER))) {
-                    String expectedCaller = serviceName + GRPC_RETURN_TYPE + GRPC_EXACT_CALLER;
-                    String diagnosticMessage = GrpcCompilerPluginConstants.CompilationErrors
-                            .INVALID_CALLER_TYPE.getError() +
-                            expectedCaller + "\" but found \"" + firstParameter + "\"";
-                    reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext, diagnosticMessage,
-                            GrpcCompilerPluginConstants.CompilationErrors.INVALID_CALLER_TYPE.getErrorCode());
-                } else if (functionSignatureNode.returnTypeDesc().isPresent()) {
-                    Node returnTypeNode = functionSignatureNode.returnTypeDesc().get().type();
-                    if (!(SyntaxKind.NIL_TYPE_DESC == returnTypeNode.kind())) {
-                        if (SyntaxKind.OPTIONAL_TYPE_DESC == returnTypeNode.kind() &&
-                                ((OptionalTypeDescriptorNode) returnTypeNode).children().size() == 2) {
-                            for (Node value : ((OptionalTypeDescriptorNode) returnTypeNode).children()) {
-                                if (!(value.kind() == SyntaxKind.ERROR_TYPE_DESC ||
-                                        value.kind() == SyntaxKind.QUESTION_MARK_TOKEN)) {
-                                    reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
-                                            GrpcCompilerPluginConstants.CompilationErrors.RETURN_WITH_CALLER.getError(),
-                                            GrpcCompilerPluginConstants.CompilationErrors
-                                                    .RETURN_WITH_CALLER.getErrorCode());
-                                    break;
-                                }
+            if (!firstParameter.toLowerCase(Locale.ENGLISH).contains(GRPC_GENERIC_CALLER)) {
+                reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
+                        GrpcCompilerPluginConstants.CompilationErrors.TWO_PARAMS_WITHOUT_CALLER.getError(),
+                        GrpcCompilerPluginConstants.CompilationErrors.TWO_PARAMS_WITHOUT_CALLER.getErrorCode());
+            } else if (!(firstParameter.startsWith(serviceName) && firstParameter.endsWith(GRPC_EXACT_CALLER))) {
+                String expectedCaller = serviceName + GRPC_RETURN_TYPE + GRPC_EXACT_CALLER;
+                String diagnosticMessage = GrpcCompilerPluginConstants.CompilationErrors
+                        .INVALID_CALLER_TYPE.getError() +
+                        expectedCaller + "\" but found \"" + firstParameter + "\"";
+                reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext, diagnosticMessage,
+                        GrpcCompilerPluginConstants.CompilationErrors.INVALID_CALLER_TYPE.getErrorCode());
+            } else if (functionSignatureNode.returnTypeDesc().isPresent()) {
+                Node returnTypeNode = functionSignatureNode.returnTypeDesc().get().type();
+                if (!(SyntaxKind.NIL_TYPE_DESC == returnTypeNode.kind())) {
+                    if (SyntaxKind.OPTIONAL_TYPE_DESC == returnTypeNode.kind() &&
+                            ((OptionalTypeDescriptorNode) returnTypeNode).children().size() == 2) {
+                        for (Node value : ((OptionalTypeDescriptorNode) returnTypeNode).children()) {
+                            if (!(value.kind() == SyntaxKind.ERROR_TYPE_DESC ||
+                                    value.kind() == SyntaxKind.QUESTION_MARK_TOKEN)) {
+                                reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
+                                        GrpcCompilerPluginConstants.CompilationErrors.RETURN_WITH_CALLER.getError(),
+                                        GrpcCompilerPluginConstants.CompilationErrors
+                                                .RETURN_WITH_CALLER.getErrorCode());
+                                break;
                             }
-                        } else if (SyntaxKind.UNION_TYPE_DESC == returnTypeNode.kind() &&
-                                ((UnionTypeDescriptorNode) returnTypeNode).children().size() == 3) {
-                            for (Node value : ((UnionTypeDescriptorNode) returnTypeNode).children()) {
-                                if (!(value.kind() == SyntaxKind.ERROR_TYPE_DESC ||
-                                        value.kind() == SyntaxKind.PIPE_TOKEN ||
-                                        value.kind() == SyntaxKind.NIL_TYPE_DESC)) {
-                                    reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
-                                            GrpcCompilerPluginConstants.CompilationErrors.RETURN_WITH_CALLER.getError(),
-                                            GrpcCompilerPluginConstants.CompilationErrors
-                                                    .RETURN_WITH_CALLER.getErrorCode());
-                                    break;
-                                }
-                            }
-                        } else {
-                            reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
-                                    GrpcCompilerPluginConstants.CompilationErrors.RETURN_WITH_CALLER.getError(),
-                                    GrpcCompilerPluginConstants.CompilationErrors
-                                            .RETURN_WITH_CALLER.getErrorCode());
                         }
+                    } else if (SyntaxKind.UNION_TYPE_DESC == returnTypeNode.kind() &&
+                            ((UnionTypeDescriptorNode) returnTypeNode).children().size() == 3) {
+                        for (Node value : ((UnionTypeDescriptorNode) returnTypeNode).children()) {
+                            if (!(value.kind() == SyntaxKind.ERROR_TYPE_DESC ||
+                                    value.kind() == SyntaxKind.PIPE_TOKEN ||
+                                    value.kind() == SyntaxKind.NIL_TYPE_DESC)) {
+                                reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
+                                        GrpcCompilerPluginConstants.CompilationErrors.RETURN_WITH_CALLER.getError(),
+                                        GrpcCompilerPluginConstants.CompilationErrors
+                                                .RETURN_WITH_CALLER.getErrorCode());
+                                break;
+                            }
+                        }
+                    } else {
+                        reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
+                                GrpcCompilerPluginConstants.CompilationErrors.RETURN_WITH_CALLER.getError(),
+                                GrpcCompilerPluginConstants.CompilationErrors
+                                        .RETURN_WITH_CALLER.getErrorCode());
                     }
                 }
-            } else if (parameterNodes.size() > 2) {
-                reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
-                        GrpcCompilerPluginConstants.CompilationErrors.MAX_PARAM_COUNT.getError(),
-                        GrpcCompilerPluginConstants.CompilationErrors.MAX_PARAM_COUNT.getErrorCode());
             }
+        } else if (parameterNodes.size() > 2) {
+            reportErrorDiagnostic(functionDefinitionNode, syntaxNodeAnalysisContext,
+                    GrpcCompilerPluginConstants.CompilationErrors.MAX_PARAM_COUNT.getError(),
+                    GrpcCompilerPluginConstants.CompilationErrors.MAX_PARAM_COUNT.getErrorCode());
         }
     }
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2695

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
