### PR TITLE
Fix `UnKnownError` when sending an error from client side due to no observe configs

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -58,7 +58,6 @@ dependencies = [
 	{org = "ballerina", name = "oauth2"},
 	{org = "ballerina", name = "protobuf"},
 	{org = "ballerina", name = "regex"},
-	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "time"}
 ]
 modules = [
@@ -237,18 +236,6 @@ version = "2.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
-]
-
-[[package]]
-org = "ballerina"
-name = "test"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "test", moduleName = "test"}
 ]
 
 [[package]]

--- a/native/src/main/java/io/ballerina/stdlib/grpc/nativeimpl/streamingclient/FunctionUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/grpc/nativeimpl/streamingclient/FunctionUtils.java
@@ -120,11 +120,12 @@ public class FunctionUtils {
                         .withDescription(errorValue.getErrorMessage().getValue()))));
                 streamingConnection.addNativeData(GrpcConstants.IS_STREAM_CANCELLED, true);
                 // Add message content to observer context.
-                ObserverContext observerContext = ObserveUtils.getObserverContextOfCurrentFrame(env);
-                observerContext.addTag(GrpcConstants.TAG_KEY_GRPC_ERROR_MESSAGE,
-                        MessageUtils.getMappingHttpStatusCode(statusCode) + " : " +
-                                errorValue.getErrorMessage().getValue());
-
+                if (ObserveUtils.isObservabilityEnabled()) {
+                    ObserverContext observerContext = ObserveUtils.getObserverContextOfCurrentFrame(env);
+                    observerContext.addTag(GrpcConstants.TAG_KEY_GRPC_ERROR_MESSAGE,
+                            MessageUtils.getMappingHttpStatusCode(statusCode) + " : " +
+                                    errorValue.getErrorMessage().getValue());
+                }
             } catch (Exception e) {
                 LOG.error("Error while sending error to server.", e);
                 return MessageUtils.getConnectorError(e);


### PR DESCRIPTION
## Purpose
$subject
This issue did not appear in the module tests because observability is enabled when the tests are running.
With the `ObserveUtils.isObservabilityEnabled()` check added in the code, it will only return true if `metrics` or `tracing` is enabled.

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3273
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
