### PR TITLE
Bump versions related to 2201.2.x to fix vulnerabilities

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "grpc"
-version = "1.4.0"
+version = "1.4.1"
 distribution = "2201.2.0"
 authors = ["Ballerina"]
 keywords = ["network", "grpc", "protobuf", "server-streaming", "client-streaming", "bidirectional-streaming"]
@@ -13,11 +13,11 @@ export = ["grpc", "grpc.types.duration", "grpc.types.struct", "grpc.types.timest
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "grpc-native"
-version = "1.4.0"
-path = "../native/build/libs/grpc-native-1.4.0.jar"
+version = "1.4.1"
+path = "../native/build/libs/grpc-native-1.4.1-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "../test-utils/build/libs/grpc-test-utils-1.4.0.jar"
+path = "../test-utils/build/libs/grpc-test-utils-1.4.1-SNAPSHOT.jar"
 scope = "testOnly"
 
 [[platform.java11.dependency]]
@@ -92,7 +92,7 @@ path = "./lib/netty-tcnative-boringssl-static-2.0.52.Final-osx-aarch_64.jar"
 path = "./lib/netty-tcnative-boringssl-static-2.0.52.Final-osx-x86_64.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/protobuf-java-3.20.1.jar"
+path = "./lib/protobuf-java-3.20.3.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/proto-google-common-protos-1.17.0.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "grpc-compiler-plugin"
 class = "io.ballerina.stdlib.grpc.plugin.GrpcCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/grpc-compiler-plugin-1.4.0.jar"
+path = "../compiler-plugin/build/libs/grpc-compiler-plugin-1.4.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -47,7 +47,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "grpc"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "crypto"},
@@ -166,7 +166,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -203,7 +203,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "protobuf"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ checkstylePluginVersion=8.18
 commonsLang3Version=3.8.1
 slf4jVersion=1.7.30
 protoGoogleCommonsVersion=1.17.0
-protobufJavaVersion=3.20.1
+protobufJavaVersion=3.20.3
 jknackHandlebarsVersion=4.0.6
 nettyVersion=4.1.77.Final
 picocliVersion=4.0.1
@@ -43,7 +43,7 @@ stdlibMimeVersion=2.4.0
 stdlibTaskVersion=2.2.2
 stdlibUrlVersion=2.2.2
 stdlibRandomVersion=1.3.0
-stdlibProtobufVersion=1.3.0
+stdlibProtobufVersion=1.3.1
 
 # Ballerinax Observer
 observeVersion=1.0.5


### PR DESCRIPTION
## Purpose
$subject
Bumping to the latest released ballerina protobuf version
## Examples

## Checklist
- [ ] `Linked to an issue`
- [ ] `Updated the changelog`
- [ ] `Added tests`
- [ ] `Updated the spec`
