### PR TITLE
Exclude `init` method from method types when defining the service

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/grpc/ServiceDefinition.java
+++ b/native/src/main/java/io/ballerina/stdlib/grpc/ServiceDefinition.java
@@ -155,7 +155,7 @@ public final class ServiceDefinition {
         MethodType[] attachedFunctions = clientEndpointType.getMethods();
         for (MethodType attachedFunction : attachedFunctions) {
             String methodName = attachedFunction.getName();
-            if (methodName.endsWith("Context")) {
+            if (methodName.endsWith("Context") || methodName.equals("init")) {
                 continue;
             }
             Descriptors.MethodDescriptor methodDescriptor = serviceDescriptor.findMethodByName(methodName);


### PR DESCRIPTION
## Purpose
$subject
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/4432
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
