### PR TITLE
Revert "Exclude `init` method from method types when defining the service"

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/grpc/ServiceDefinition.java
+++ b/native/src/main/java/io/ballerina/stdlib/grpc/ServiceDefinition.java
@@ -155,7 +155,7 @@ public final class ServiceDefinition {
         MethodType[] attachedFunctions = clientEndpointType.getMethods();
         for (MethodType attachedFunction : attachedFunctions) {
             String methodName = attachedFunction.getName();
-            if (methodName.endsWith("Context") || methodName.equals("init")) {
+            if (methodName.endsWith("Context")) {
                 continue;
             }
             Descriptors.MethodDescriptor methodDescriptor = serviceDescriptor.findMethodByName(methodName);


### PR DESCRIPTION
Reverts ballerina-platform/module-ballerina-grpc#1272