### PR TITLE
removed else block

### DIFF
--- a/ballerina-tests/tests/46_empty_values_pb.bal
+++ b/ballerina-tests/tests/46_empty_values_pb.bal
@@ -88,8 +88,6 @@ public isolated client class ClientStrWithEmptyStreamingClient {
         var response = check self.sClient->receive();
         if response is () {
             return response;
-        } else {
-            _ = response;
         }
     }
 


### PR DESCRIPTION
## Purpose

In client streaming, when the server is sending Empty messages, the client's receive method currently looks as follows.

```
isolated remote function receive() returns grpc:Error? {
    var response = check self.sClient->receive();
    if response is () {
        return response;
    } else {
        _ = response;
    }
}
```

The else block is not needed and we need to remove it.


Issue - https://github.com/ballerina-platform/ballerina-library/issues/2442