### PR TITLE
Consolidate exported gRPC endpoint details into a single endpoints.yaml

### DIFF
--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/EndpointDetailsExtractorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/EndpointDetailsExtractorTest.java
@@ -20,6 +20,8 @@ package io.ballerina.stdlib.grpc.plugin;
 
 import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.JBallerinaBackend;
+import io.ballerina.projects.JvmTarget;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.BuildProject;
@@ -43,17 +45,18 @@ public class EndpointDetailsExtractorTest {
 
     private static final String TARGET_DIR = "target";
     private static final String ARTIFACT_DIR = "artifact";
+    private static final String ENDPOINTS_FILE_NAME = "endpoints.yaml";
 
     @Test
     public void testHardcodedPortExtraction() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_10");
         try {
-            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath, true);
+            DiagnosticResult diagnosticResult = buildProject(projectDirPath, true);
             Path artifactDir = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR);
             Assert.assertTrue(Files.exists(artifactDir));
-            Path endpointYaml = artifactDir.resolve("grpc_service_HelloWorld_endpoint.yaml");
+            Path endpointsYaml = artifactDir.resolve(ENDPOINTS_FILE_NAME);
             assertNoCompilationErrors(diagnosticResult);
-            assertEndpointPort(endpointYaml, 9090);
+            assertEndpointPort(endpointsYaml, 9090);
         } finally {
             deleteDirectories(projectDirPath);
         }
@@ -63,12 +66,12 @@ public class EndpointDetailsExtractorTest {
     public void testConfigurablePortWithDefaultValue() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_24");
         try {
-            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath, true);
+            DiagnosticResult diagnosticResult = buildProject(projectDirPath, true);
             Path artifactDir = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR);
             Assert.assertTrue(Files.exists(artifactDir));
-            Path endpointYaml = artifactDir.resolve("grpc_unary_blocking_service_HelloWorld_endpoint.yaml");
+            Path endpointsYaml = artifactDir.resolve(ENDPOINTS_FILE_NAME);
             assertNoCompilationErrors(diagnosticResult);
-            assertEndpointPort(endpointYaml, 9090);
+            assertEndpointPort(endpointsYaml, 9090);
         } finally {
             deleteDirectories(projectDirPath);
         }
@@ -78,14 +81,13 @@ public class EndpointDetailsExtractorTest {
     public void testConfigurablePortWithRequiredValue() throws IOException {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_25");
         try {
-            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath, true);
+            DiagnosticResult diagnosticResult = buildProject(projectDirPath, true);
             assertNoCompilationErrors(diagnosticResult);
 
-            Path artifactDir = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR);
-            Assert.assertTrue(Files.exists(artifactDir));
-            Path endpointYaml = artifactDir.resolve("grpc_unary_blocking_service_HelloWorld_endpoint.yaml");
-            Assert.assertTrue(Files.notExists(endpointYaml),
-                    "No endpoint YAML should be generated when the required port cannot be resolved "
+            Path endpointsYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
+                    .resolve(ENDPOINTS_FILE_NAME);
+            Assert.assertTrue(Files.notExists(endpointsYaml),
+                    "No endpoints YAML should be generated when the required port cannot be resolved "
                             + "(no bogus port-0 entry)");
         } finally {
             deleteDirectories(projectDirPath);
@@ -96,23 +98,33 @@ public class EndpointDetailsExtractorTest {
     public void testServiceArtifactEndpointYamlContainsExpectedPortForMultipleServices() throws Exception {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_26");
         try {
-            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath, true);
+            DiagnosticResult diagnosticResult = buildProject(projectDirPath, true);
             Assert.assertEquals(diagnosticResult.errorCount(), 0);
-            assertEndpointPort(projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
-                            .resolve("helloballerina_service_HelloBallerina_endpoint.yaml"),
-                    8091);
-            assertEndpointPort(projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
-                    .resolve("helloworld_service_HelloWorld_endpoint.yaml"), 9090);
+            Path endpointsYaml = projectDirPath.resolve(TARGET_DIR).resolve(ARTIFACT_DIR)
+                    .resolve(ENDPOINTS_FILE_NAME);
+            Assert.assertTrue(Files.exists(endpointsYaml), "Consolidated endpoints YAML should be generated");
+            String content = Files.readString(endpointsYaml);
+            Assert.assertTrue(content.contains("port: 8091"), "Expected port 8091 for HelloBallerina service");
+            Assert.assertTrue(content.contains("port: 9090"), "Expected port 9090 for HelloWorld service");
         } finally {
             deleteDirectories(projectDirPath);
         }
     }
 
-    private static DiagnosticResult getDiagnosticResults(Path projectDirPath, boolean isExportEndpoints) {
+    private static DiagnosticResult buildProject(Path projectDirPath, boolean isExportEndpoints)
+            throws IOException {
+        System.setProperty("ballerina.home", DISTRIBUTION_PATH.toString());
         BuildOptions buildOptions = BuildOptions.builder().setExportEndpoints(isExportEndpoints).build();
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath, buildOptions);
         PackageCompilation compilation = project.currentPackage().getCompilation();
-        return compilation.diagnosticResult();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        if (diagnosticResult.errorCount() == 0) {
+            JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_21);
+            Path executablePath = project.targetDir().resolve("bin").resolve("output.jar");
+            Files.createDirectories(executablePath.getParent());
+            jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, executablePath);
+        }
+        return diagnosticResult;
     }
 
     private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
@@ -120,14 +132,14 @@ public class EndpointDetailsExtractorTest {
         return ProjectEnvironmentBuilder.getBuilder(environment);
     }
 
-    private static void assertEndpointPort(Path endpointYaml, int expectedPort) throws IOException {
-        try (Stream<String> lines = Files.lines(endpointYaml)) {
+    private static void assertEndpointPort(Path endpointsYaml, int expectedPort) throws IOException {
+        try (Stream<String> lines = Files.lines(endpointsYaml)) {
             String portLine = lines.map(String::trim)
                     .filter(line -> line.startsWith("port:"))
                     .findFirst()
-                    .orElseThrow(() -> new AssertionError("No port field found in: " + endpointYaml));
+                    .orElseThrow(() -> new AssertionError("No port field found in: " + endpointsYaml));
             int actualPort = Integer.parseInt(portLine.substring("port:".length()).trim());
-            Assert.assertEquals(actualPort, expectedPort, "Unexpected endpoint port in " + endpointYaml);
+            Assert.assertEquals(actualPort, expectedPort, "Unexpected endpoint port in " + endpointsYaml);
         }
     }
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/EndpointDetailsExtractorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/EndpointDetailsExtractorTest.java
@@ -120,9 +120,9 @@ public class EndpointDetailsExtractorTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         if (diagnosticResult.errorCount() == 0) {
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_21);
-            Path executablePath = project.targetDir().resolve("bin").resolve("output.jar");
-            Files.createDirectories(executablePath.getParent());
-            jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, executablePath);
+            Path binDir = project.targetDir().resolve("bin");
+            Files.createDirectories(binDir);
+            jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, binDir.resolve("output.jar"));
         }
         return diagnosticResult;
     }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/ServiceArtifactExtractorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/ServiceArtifactExtractorTest.java
@@ -181,12 +181,6 @@ public class ServiceArtifactExtractorTest {
         }
     }
 
-    private long countOccurrences(Path file, String needle) throws IOException {
-        try (Stream<String> lines = Files.lines(file)) {
-            return lines.filter(line -> line.contains(needle)).count();
-        }
-    }
-
     private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
         Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
         return ProjectEnvironmentBuilder.getBuilder(environment);
@@ -201,9 +195,9 @@ public class ServiceArtifactExtractorTest {
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         if (diagnosticResult.errorCount() == 0) {
             JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_21);
-            Path executablePath = project.targetDir().resolve("bin").resolve("output.jar");
-            Files.createDirectories(executablePath.getParent());
-            jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, executablePath);
+            Path binDir = project.targetDir().resolve("bin");
+            Files.createDirectories(binDir);
+            jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, binDir.resolve("output.jar"));
         }
         return diagnosticResult;
     }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/ServiceArtifactExtractorTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/grpc/plugin/ServiceArtifactExtractorTest.java
@@ -1,7 +1,27 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package io.ballerina.stdlib.grpc.plugin;
 
 import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.JBallerinaBackend;
+import io.ballerina.projects.JvmTarget;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.BuildProject;
@@ -28,20 +48,20 @@ public class ServiceArtifactExtractorTest {
     private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime")
             .toAbsolutePath();
     private static final String ARTIFACT_DIR = "artifact";
-    private static final String ENDPOINT_SUFFIX = "_endpoint.yaml";
+    private static final String ENDPOINTS_FILE_NAME = "endpoints.yaml";
     private static final String PROTO_SUFFIX = ".proto";
 
     @Test
     public void testExportEndpointsForSimpleService() throws Exception {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_20");
         try {
-            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath, true);
+            DiagnosticResult diagnosticResult = buildProject(projectDirPath, true);
             assertNoCompilationErrors(diagnosticResult);
 
             Path artifactDir = projectDirPath.resolve("target").resolve(ARTIFACT_DIR);
             Assert.assertTrue(Files.exists(artifactDir), "Artifact directory should exist");
-            assertArtifactCount(artifactDir, ENDPOINT_SUFFIX, 1L,
-                    "Expected one endpoint YAML for package_20");
+            Assert.assertTrue(Files.exists(artifactDir.resolve(ENDPOINTS_FILE_NAME)),
+                    "Expected consolidated endpoints YAML for package_20");
             assertArtifactCount(artifactDir, PROTO_SUFFIX, 1L,
                     "Expected one proto file for package_20");
         } finally {
@@ -53,7 +73,7 @@ public class ServiceArtifactExtractorTest {
     public void testBuildWithoutExportEndpointsFlag() throws Exception {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_20");
         try {
-            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath, false);
+            DiagnosticResult diagnosticResult = buildProject(projectDirPath, false);
             assertNoCompilationErrors(diagnosticResult);
 
             Path artifactDir = projectDirPath.resolve("target").resolve(ARTIFACT_DIR);
@@ -68,7 +88,7 @@ public class ServiceArtifactExtractorTest {
     public void testExportEndpointsWithCompilationErrors() throws Exception {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_03");
         try {
-            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath, true);
+            DiagnosticResult diagnosticResult = buildProject(projectDirPath, true);
             Assert.assertNotEquals(diagnosticResult.errorCount(), 0);
         } finally {
             deleteDirectories(projectDirPath);
@@ -79,15 +99,17 @@ public class ServiceArtifactExtractorTest {
     public void testExportEndpointsForMultipleGrpcServicesAcrossFiles() throws Exception {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_14");
         try {
-            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath, true);
+            DiagnosticResult diagnosticResult = buildProject(projectDirPath, true);
             assertNoInvalidServiceNameErrors(diagnosticResult);
 
             Path artifactDir = projectDirPath.resolve("target").resolve(ARTIFACT_DIR);
             Assert.assertTrue(Files.exists(artifactDir), "Artifact directory should exist");
-            assertArtifactCount(artifactDir, ENDPOINT_SUFFIX, 2L,
-                    "Expected endpoint artifacts for both services in package_14");
             assertArtifactCount(artifactDir, PROTO_SUFFIX, 2L,
                     "Expected proto artifacts for both services in package_14");
+            // Both services in package_14 have INVALID_SERVICE_NAME errors, so the package never reaches
+            // code generation - the consolidated endpoints.yaml (written once codegen completes) is not produced.
+            Assert.assertFalse(Files.exists(artifactDir.resolve(ENDPOINTS_FILE_NAME)),
+                    "No consolidated endpoints YAML should be generated when the package has compilation errors");
         } finally {
             deleteDirectories(projectDirPath);
         }
@@ -97,13 +119,14 @@ public class ServiceArtifactExtractorTest {
     public void testExportEndpointsForMultipleServicesInSingleFile() throws Exception {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_28");
         try {
-            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath, true);
+            DiagnosticResult diagnosticResult = buildProject(projectDirPath, true);
             assertNoCompilationErrors(diagnosticResult);
 
             Path artifactDir = projectDirPath.resolve("target").resolve(ARTIFACT_DIR);
             Assert.assertTrue(Files.exists(artifactDir), "Artifact directory should exist");
-            assertArtifactCount(artifactDir, ENDPOINT_SUFFIX, 1L,
-                    "Expected one endpoint YAML from the single gRPC service in the file");
+            Path endpointsYaml = artifactDir.resolve(ENDPOINTS_FILE_NAME);
+            Assert.assertTrue(Files.exists(endpointsYaml),
+                    "Expected one consolidated endpoints YAML from the single gRPC service in the file");
             assertArtifactCount(artifactDir, PROTO_SUFFIX, 1L,
                     "Expected one proto artifact from the single gRPC service in the file");
         } finally {
@@ -115,25 +138,28 @@ public class ServiceArtifactExtractorTest {
     public void testEndpointYamlFallbackNamingForEmptyServiceNames() throws Exception {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_14");
         try {
-            DiagnosticResult diagnosticResult = getDiagnosticResults(projectDirPath, true);
+            DiagnosticResult diagnosticResult = buildProject(projectDirPath, true);
             assertNoInvalidServiceNameErrors(diagnosticResult);
 
             Path artifactDir = projectDirPath.resolve("target").resolve(ARTIFACT_DIR);
             Assert.assertTrue(Files.exists(artifactDir), "Artifact directory should exist");
 
-            List<String> endpointFiles;
+            // Both services intentionally have empty/invalid names, exercising the same fallback
+            // hash-based naming (FileNameGeneratorUtil) used for both the schemaPath and the proto file name.
+            // The package never reaches code generation, so this is observed via the .proto files rather
+            // than the consolidated endpoints.yaml (which is only written once codegen completes).
+            List<String> protoFiles;
             try (Stream<Path> paths = Files.walk(artifactDir)) {
-                endpointFiles = paths
+                protoFiles = paths
                         .map(this::safeFileName)
-                        .filter(fileName -> fileName.endsWith(ENDPOINT_SUFFIX))
+                        .filter(fileName -> fileName.endsWith(PROTO_SUFFIX))
                         .toList();
             }
-
-            Assert.assertEquals(endpointFiles.size(), 2,
-                    "Expected endpoint YAML artifacts for both services with empty names");
-            Assert.assertTrue(endpointFiles.stream()
-                            .allMatch(fileName -> fileName.matches(".+_-?[0-9]+_endpoint\\.yaml")),
-                    "Endpoint YAML files should use fallback hash-based naming for empty service names");
+            Assert.assertEquals(protoFiles.size(), 2,
+                    "Expected proto artifacts for both services with empty names");
+            Assert.assertTrue(protoFiles.stream()
+                            .allMatch(fileName -> fileName.matches(".+_-?[0-9]+\\.proto")),
+                    "Proto files should use fallback hash-based naming for empty service names");
         } finally {
             deleteDirectories(projectDirPath);
         }
@@ -155,16 +181,31 @@ public class ServiceArtifactExtractorTest {
         }
     }
 
+    private long countOccurrences(Path file, String needle) throws IOException {
+        try (Stream<String> lines = Files.lines(file)) {
+            return lines.filter(line -> line.contains(needle)).count();
+        }
+    }
+
     private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
         Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
         return ProjectEnvironmentBuilder.getBuilder(environment);
     }
 
-    private static DiagnosticResult getDiagnosticResults(Path projectDirPath, boolean isExportEndpoints) {
+    private static DiagnosticResult buildProject(Path projectDirPath, boolean isExportEndpoints)
+            throws IOException {
+        System.setProperty("ballerina.home", DISTRIBUTION_PATH.toString());
         BuildOptions buildOptions = BuildOptions.builder().setExportEndpoints(isExportEndpoints).build();
         BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath, buildOptions);
         PackageCompilation compilation = project.currentPackage().getCompilation();
-        return compilation.diagnosticResult();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        if (diagnosticResult.errorCount() == 0) {
+            JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(compilation, JvmTarget.JAVA_21);
+            Path executablePath = project.targetDir().resolve("bin").resolve("output.jar");
+            Files.createDirectories(executablePath.getParent());
+            jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, executablePath);
+        }
+        return diagnosticResult;
     }
 
     private void deleteDirectories(Path projectDirPath) throws IOException {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcCodeAnalyzer.java
@@ -22,13 +22,22 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.CodeAnalysisContext;
 import io.ballerina.projects.plugins.CodeAnalyzer;
 
+import java.util.Map;
+
 /**
  * NATS Code Analyzer.
  */
 public class GrpcCodeAnalyzer extends CodeAnalyzer {
+    private final Map<String, Object> ctxData;
+
+    public GrpcCodeAnalyzer(Map<String, Object> ctxData) {
+        this.ctxData = ctxData;
+    }
+
     @Override
     public void init(CodeAnalysisContext codeAnalysisContext) {
         codeAnalysisContext.addSyntaxNodeAnalysisTask(new GrpcServiceValidator(), SyntaxKind.SERVICE_DECLARATION);
-        codeAnalysisContext.addSyntaxNodeAnalysisTask(new GrpcServiceAnalysisTask(), SyntaxKind.SERVICE_DECLARATION);
+        codeAnalysisContext.addSyntaxNodeAnalysisTask(
+                new GrpcServiceAnalysisTask(ctxData), SyntaxKind.SERVICE_DECLARATION);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcCompilerPlugin.java
@@ -20,6 +20,14 @@ package io.ballerina.stdlib.grpc.plugin;
 
 import io.ballerina.projects.plugins.CompilerPlugin;
 import io.ballerina.projects.plugins.CompilerPluginContext;
+import io.ballerina.stdlib.grpc.plugin.endpointyaml.generator.Endpoint;
+import io.ballerina.stdlib.grpc.plugin.endpointyaml.generator.GrpcEndpointsLifecycleListener;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+
+import static io.ballerina.stdlib.grpc.plugin.GrpcCompilerPluginConstants.GRPC_EXPORTED_ENDPOINTS;
 
 /**
  * gRPC Compiler plugin.
@@ -28,6 +36,9 @@ public class GrpcCompilerPlugin extends CompilerPlugin {
 
     @Override
     public void init(CompilerPluginContext compilerPluginContext) {
-        compilerPluginContext.addCodeAnalyzer(new GrpcCodeAnalyzer());
+        Map<String, Object> ctxData = compilerPluginContext.userData();
+        ctxData.put(GRPC_EXPORTED_ENDPOINTS, Collections.synchronizedList(new ArrayList<Endpoint>()));
+        compilerPluginContext.addCodeAnalyzer(new GrpcCodeAnalyzer(ctxData));
+        compilerPluginContext.addCompilerLifecycleListener(new GrpcEndpointsLifecycleListener(ctxData));
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcCompilerPluginConstants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcCompilerPluginConstants.java
@@ -32,6 +32,7 @@ public final class GrpcCompilerPluginConstants {
     public static final String GRPC_DESCRIPTOR_ANNOTATION_NAME = "Descriptor";
     public static final String BALLERINA_ORG_NAME = "ballerina";
     public static final String GRPC_PACKAGE_NAME = "grpc";
+    public static final String GRPC_EXPORTED_ENDPOINTS = "GrpcExportedEndpoints";
 
     /**
      * Compilation errors: Diagnostic error messages and IDs.

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcServiceAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/GrpcServiceAnalysisTask.java
@@ -25,6 +25,7 @@ import io.ballerina.projects.BuildOptions;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.grpc.plugin.endpointyaml.generator.Endpoint;
 import io.ballerina.stdlib.grpc.plugin.endpointyaml.generator.EndpointYamlGenerator;
 import io.ballerina.stdlib.grpc.plugin.endpointyaml.generator.ProtoFileExporter;
 import io.ballerina.tools.diagnostics.DiagnosticFactory;
@@ -32,12 +33,22 @@ import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static io.ballerina.stdlib.grpc.plugin.GrpcCompilerPluginConstants.GRPC_EXPORTED_ENDPOINTS;
 import static io.ballerina.stdlib.grpc.plugin.GrpcServiceValidator.isBallerinaGrpcService;
 
 public class GrpcServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    private final Map<String, Object> ctxData;
+
+    public GrpcServiceAnalysisTask(Map<String, Object> ctxData) {
+        this.ctxData = ctxData;
+    }
+
     @Override
+    @SuppressWarnings("unchecked")
     public void perform(SyntaxNodeAnalysisContext context) {
         ServiceDeclarationNode serviceNode = (ServiceDeclarationNode) context.node();
 
@@ -61,7 +72,8 @@ public class GrpcServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisC
         ProtoFileExporter protoFileExporter = new ProtoFileExporter(context);
 
         try {
-            endpointYamlGeneratorGrpc.writeEndpointYamls();
+            List<Endpoint> collectedEndpoints = (List<Endpoint>) ctxData.get(GRPC_EXPORTED_ENDPOINTS);
+            collectedEndpoints.addAll(endpointYamlGeneratorGrpc.getEndpoints());
             protoFileExporter.exportProtoFile();
         } catch (IOException e) {
             context.reportDiagnostic(

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/endpointyaml/generator/Endpoint.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/endpointyaml/generator/Endpoint.java
@@ -19,16 +19,22 @@
 package io.ballerina.stdlib.grpc.plugin.endpointyaml.generator;
 
 public class Endpoint {
+    private final String name;
     private final int port;
     private final String basePath;
     private final String type;
     private final String schemaPath;
 
-    Endpoint(int port, String basePath, String type, String schemaPath) {
+    Endpoint(String name, int port, String basePath, String type, String schemaPath) {
+        this.name = name;
         this.port = port;
         this.basePath = basePath;
         this.type = type;
         this.schemaPath = schemaPath;
+    }
+
+    public String getName() {
+        return name;
     }
 
     public String getBasePath() {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/endpointyaml/generator/EndpointYamlGenerator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/endpointyaml/generator/EndpointYamlGenerator.java
@@ -41,8 +41,6 @@ import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
-import io.ballerina.projects.Package;
-import io.ballerina.projects.Project;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.runtime.api.utils.IdentifierUtils;
 import io.ballerina.tools.diagnostics.DiagnosticFactory;
@@ -58,8 +56,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.ballerina.stdlib.grpc.plugin.endpointyaml.generator.FileNameGeneratorUtil.resolveContractFileName;
-
 public class EndpointYamlGenerator {
     private final ServiceDeclarationNode node;
     private final SyntaxNodeAnalysisContext context;
@@ -69,8 +65,7 @@ public class EndpointYamlGenerator {
 
     private static final String ARTIFACT = "artifact";
     private static final String GRPC = "GRPC";
-    private static final String YAML_EXTENSION = ".yaml";
-    private static final String ENDPOINT_SUFFIX = "_endpoint";
+    private static final String ENDPOINTS_FILE_NAME = "endpoints.yaml";
 
     private record ListenerInfo(Optional<ParenthesizedArgList> argList) {
     }
@@ -102,7 +97,7 @@ public class EndpointYamlGenerator {
             if (port.isEmpty()) {
                 continue;
             }
-            endpoints.add(new Endpoint(port.get(), basePath, GRPC, this.schemaFileName));
+            endpoints.add(new Endpoint(basePath, port.get(), basePath, GRPC, this.schemaFileName));
         }
         return endpoints;
     }
@@ -255,29 +250,13 @@ public class EndpointYamlGenerator {
         return basePath.toString();
     }
 
-    public void writeEndpointYamls() throws IOException {
-        for (Endpoint endpoint : getEndpoints()) {
-            Path outPath = resolveOutputPath();
-            String fileName = buildEndpointFileName(outPath);
-            Path path = outPath.resolve(ARTIFACT).resolve(fileName + YAML_EXTENSION).toAbsolutePath();
-            writeYaml(path, new EndpointWrapper(endpoint));
-        }
-    }
-
-    private Path resolveOutputPath() throws IOException {
-        Package currentPackage = this.context.currentPackage();
-        Project project = currentPackage.project();
-        Path outPath = project.targetDir();
+    public static void writeEndpointsYaml(Path outPath, List<Endpoint> endpoints) throws IOException {
         Files.createDirectories(outPath.resolve(ARTIFACT));
-        return outPath;
+        Path path = outPath.resolve(ARTIFACT).resolve(ENDPOINTS_FILE_NAME).toAbsolutePath();
+        writeYaml(path, new EndpointsWrapper(endpoints));
     }
 
-    private String buildEndpointFileName(Path outPath) {
-        String base = schemaFileName.split("\\.")[0] + ENDPOINT_SUFFIX;
-        return resolveContractFileName(outPath.resolve(ARTIFACT), base);
-    }
-
-    private void writeYaml(Path path, EndpointWrapper wrapper) throws IOException {
+    private static void writeYaml(Path path, EndpointsWrapper wrapper) throws IOException {
         YAMLFactory yamlFactory = YAMLFactory.builder()
                 .disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
                 .build();
@@ -287,7 +266,7 @@ public class EndpointYamlGenerator {
         try (Writer writer = Files.newBufferedWriter(path)) {
             mapper.writeValue(writer, wrapper);
         } catch (IOException e) {
-            throw new IOException("Failed to write endpoint yaml to " + path, e);
+            throw new IOException("Failed to write endpoints yaml to " + path, e);
         }
     }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/endpointyaml/generator/EndpointsWrapper.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/endpointyaml/generator/EndpointsWrapper.java
@@ -18,14 +18,19 @@
 
 package io.ballerina.stdlib.grpc.plugin.endpointyaml.generator;
 
-public class EndpointWrapper {
-    private final Endpoint endpoint;
+import java.util.List;
 
-    public EndpointWrapper(Endpoint endpoint) {
-        this.endpoint = endpoint;
+/*
+ * Represents the wrapper class to serialize the consolidated list of endpoints
+ */
+public class EndpointsWrapper {
+    private final List<Endpoint> endpoints;
+
+    public EndpointsWrapper(List<Endpoint> endpoints) {
+        this.endpoints = List.copyOf(endpoints);
     }
 
-    public Endpoint getEndpoint() {
-        return endpoint;
+    public List<Endpoint> getEndpoints() {
+        return endpoints;
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/endpointyaml/generator/EndpointsYamlWriterTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/endpointyaml/generator/EndpointsYamlWriterTask.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.grpc.plugin.endpointyaml.generator;
+
+import io.ballerina.projects.Package;
+import io.ballerina.projects.plugins.CompilerLifecycleEventContext;
+import io.ballerina.projects.plugins.CompilerLifecycleTask;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextRange;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static io.ballerina.stdlib.grpc.plugin.GrpcCompilerPluginConstants.GRPC_EXPORTED_ENDPOINTS;
+
+/*
+ * Writes every endpoint collected by {@link GrpcServiceAnalysisTask} during code analysis into a single,
+ * consolidated endpoints.yaml, once for the whole compilation after code generation has completed.
+ */
+public class EndpointsYamlWriterTask implements CompilerLifecycleTask<CompilerLifecycleEventContext> {
+    private final Map<String, Object> ctxData;
+
+    public EndpointsYamlWriterTask(Map<String, Object> ctxData) {
+        this.ctxData = ctxData;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void perform(CompilerLifecycleEventContext context) {
+        List<Endpoint> endpoints = (List<Endpoint>) ctxData.get(GRPC_EXPORTED_ENDPOINTS);
+        if (endpoints == null || endpoints.isEmpty()) {
+            return;
+        }
+        Package currentPackage = context.currentPackage();
+        if (currentPackage == null) {
+            return;
+        }
+        try {
+            EndpointYamlGenerator.writeEndpointsYaml(currentPackage.project().targetDir(), endpoints);
+        } catch (IOException e) {
+            context.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                    new DiagnosticInfo("GRPC_PLUGIN_DEBUG", "[grpc-plugin] " + e.getMessage(),
+                            DiagnosticSeverity.ERROR),
+                    NULL_LOCATION));
+        }
+    }
+
+    private static final Location NULL_LOCATION = new Location() {
+        private static final LineRange LINE_RANGE =
+                LineRange.from("", LinePosition.from(0, 0), LinePosition.from(0, 0));
+        private static final TextRange TEXT_RANGE = TextRange.from(0, 0);
+
+        @Override
+        public LineRange lineRange() {
+            return LINE_RANGE;
+        }
+
+        @Override
+        public TextRange textRange() {
+            return TEXT_RANGE;
+        }
+    };
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/endpointyaml/generator/GrpcEndpointsLifecycleListener.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/grpc/plugin/endpointyaml/generator/GrpcEndpointsLifecycleListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.grpc.plugin.endpointyaml.generator;
+
+import io.ballerina.projects.plugins.CompilerLifecycleContext;
+import io.ballerina.projects.plugins.CompilerLifecycleListener;
+
+import java.util.Map;
+
+/*
+ * Registers the {@code EndpointsYamlWriterTask} to run once the whole compilation's code generation
+ * has completed, so it can aggregate every service's endpoint details into a single endpoints.yaml.
+ */
+public class GrpcEndpointsLifecycleListener extends CompilerLifecycleListener {
+    private final Map<String, Object> ctxData;
+
+    public GrpcEndpointsLifecycleListener(Map<String, Object> ctxData) {
+        this.ctxData = ctxData;
+    }
+
+    @Override
+    public void init(CompilerLifecycleContext context) {
+        context.addCodeGenerationCompletedTask(new EndpointsYamlWriterTask(ctxData));
+    }
+}

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,39 @@
+<!--
+  ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<FindBugsFilter>
+    <Match>
+        <Class name="io.ballerina.stdlib.grpc.plugin.GrpcCodeAnalyzer"/>
+        <Field name="ctxData"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+    <Match>
+        <Class name="io.ballerina.stdlib.grpc.plugin.GrpcServiceAnalysisTask"/>
+        <Field name="ctxData"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+    <Match>
+        <Class name="io.ballerina.stdlib.grpc.plugin.endpointyaml.generator.EndpointsYamlWriterTask"/>
+        <Field name="ctxData"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+    <Match>
+        <Class name="io.ballerina.stdlib.grpc.plugin.endpointyaml.generator.GrpcEndpointsLifecycleListener"/>
+        <Field name="ctxData"/>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+    </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Purpose

Fixes wso2-enterprise/integration-engineering#2213 (the gRPC counterpart of #2166), which asked to move the endpoint-artifact export path off `SyntaxNodeAnalysisContext` to `CompilerLifecycleEventContext`. This mirrors [module-ballerina-http#2660](https://github.com/ballerina-platform/module-ballerina-http/pull/2660), applied here for gRPC.

This targets the `export-endpoint` branch (not `master`) since gRPC's per-service `endpoint.yaml` feature (#1740 / #1756) hasn't merged to `master` yet — this PR builds directly on top of it.

## Approach

`GrpcServiceAnalysisTask` previously ran once per `SERVICE_DECLARATION` node (via `SyntaxNodeAnalysisContext`), writing an individual endpoint file per service. Generating one consolidated file requires running once, after every service has been processed — which is what `CompilerLifecycleEventContext` (reached via `CompilerLifecycleListener.addCodeGenerationCompletedTask`) is for: it fires once per compilation, after code generation completes.

As with the HTTP fix, moving the *entire* per-service flow there isn't safe — port/base-path resolution needs the full `SyntaxNodeAnalysisContext` (module visitors, semantic model) that isn't reliably available post-codegen. So the change is split:
- `GrpcServiceAnalysisTask` stays a `SyntaxNodeAnalysisContext`-based, per-service task (unchanged port/base-path resolution, still one `.proto` file per service) but now collects each service's `Endpoint` into a shared, synchronized list instead of writing its own endpoint file.
- A new `EndpointsYamlWriterTask`, registered through `GrpcEndpointsLifecycleListener` via `CompilerLifecycleEventContext`, runs once after code generation completes and writes that shared list out as a single `target/artifact/endpoints.yaml`.

One consequence of this (also true on the HTTP side): if the package has any compilation error anywhere, code generation never runs, so no `endpoints.yaml` is produced at all for that build — even for services that were otherwise fine. `.proto` files are unaffected since they're still written during analysis.

Also adds a root-level `spotbugs-exclude.xml` (missing from this repo until now) with entries for the new classes that intentionally share a mutable `ctxData` map across the analyzer, lifecycle listener, and writer task — mirroring the equivalent `EI_EXPOSE_REP2` exclusions already present in `module-ballerina-http`'s `compiler-plugin`.

## Output shape

```yaml
endpoints:
  - name: "/userservice"
    port: 9090
    basePath: "/userservice"
    type: "GRPC"
    schemaPath: "service_userservice.proto"
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [x] Checked native-image compatibility (no reflection/dynamic class loading introduced)

## Test plan
- `EndpointDetailsExtractorTest` and `ServiceArtifactExtractorTest` updated for the consolidated format (10/10 passing locally, triggering real code generation in-process via `JBallerinaBackend`, covering hardcoded/configurable/required ports, multiple services in one and across files, compilation errors, and fallback hash-based naming for empty service names).
- `checkstyleMain`/`spotbugsMain` pass on `:grpc-compiler-plugin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)